### PR TITLE
[#32] 알림 빈도 추가

### DIFF
--- a/src/main/kotlin/com/deepromeet/atcha/auth/api/request/SignUpRequest.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/auth/api/request/SignUpRequest.kt
@@ -8,7 +8,8 @@ data class SignUpRequest(
     val lat: Double,
     val log: Double,
     val alertAgreement: Boolean,
-    val trackingAgreement: Boolean
+    val trackingAgreement: Boolean,
+    val alertFrequencies: Set<Int>
 ) {
     fun toSignUpInfo() =
         SignUpInfo(
@@ -17,6 +18,7 @@ data class SignUpRequest(
             lat = lat,
             log = log,
             alertAgreement = alertAgreement,
-            trackingAgreement = trackingAgreement
+            trackingAgreement = trackingAgreement,
+            alertFrequencies = alertFrequencies
         )
 }

--- a/src/main/kotlin/com/deepromeet/atcha/auth/domain/SignUpInfo.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/auth/domain/SignUpInfo.kt
@@ -9,7 +9,8 @@ data class SignUpInfo(
     val lat: Double,
     val log: Double,
     val alertAgreement: Boolean,
-    val trackingAgreement: Boolean
+    val trackingAgreement: Boolean,
+    val alertFrequencies: Set<Int>
 ) {
     fun getAddress(): Address = Address(address, lat, log)
 

--- a/src/main/kotlin/com/deepromeet/atcha/user/api/request/UserInfoUpdateRequest.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/user/api/request/UserInfoUpdateRequest.kt
@@ -9,7 +9,8 @@ data class UserInfoUpdateRequest(
     val lat: Double?,
     val log: Double?,
     val alertAgreement: Boolean?,
-    val trackingAgreement: Boolean?
+    val trackingAgreement: Boolean?,
+    val alertFrequencies: Set<Int>?
 ) {
     fun toUpdateUserInfo(): UserUpdateInfo {
         return UserUpdateInfo(
@@ -19,7 +20,8 @@ data class UserInfoUpdateRequest(
             lat = lat,
             log = log,
             alertAgreement = alertAgreement,
-            trackingAgreement = trackingAgreement
+            trackingAgreement = trackingAgreement,
+            alertFrequencies = alertFrequencies
         )
     }
 }

--- a/src/main/kotlin/com/deepromeet/atcha/user/api/response/UserInfoResponse.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/user/api/response/UserInfoResponse.kt
@@ -11,7 +11,8 @@ data class UserInfoResponse(
     val lat: Double,
     val lon: Double,
     val alertAgreement: Boolean,
-    val trackingAgreement: Boolean
+    val trackingAgreement: Boolean,
+    val alertFrequencies: Set<Int>
 ) {
     companion object {
         fun from(domain: User) =
@@ -24,7 +25,8 @@ data class UserInfoResponse(
                 domain.address.lat,
                 domain.address.lon,
                 domain.agreement.alert,
-                domain.agreement.tracking
+                domain.agreement.tracking,
+                domain.alertFrequencies
             )
     }
 }

--- a/src/main/kotlin/com/deepromeet/atcha/user/domain/User.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/user/domain/User.kt
@@ -1,10 +1,15 @@
 package com.deepromeet.atcha.user.domain
 
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
 import jakarta.persistence.Table
 
 @Entity
@@ -20,6 +25,10 @@ class User(
     var address: Address = Address(),
     @Embedded
     var agreement: Agreement = Agreement(),
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "user_alert_frequencies", joinColumns = [JoinColumn(name = "user_id")])
+    @Column(name = "alert_frequencies")
+    var alertFrequencies: MutableSet<Int> = mutableSetOf(),
     var isDeleted: Boolean = false
 ) {
     override fun equals(other: Any?): Boolean {
@@ -37,12 +46,12 @@ class User(
 
     override fun toString(): String {
         return "User(id=$id, " +
-            "providerId=$providerId," +
-            " nickname='$nickname'," +
-            " profileImageUrl='$profileImageUrl'," +
-            " address=$address," +
-            " agreement=$agreement," +
-            " isDeleted=$isDeleted" +
-            ")"
+            "providerId=$providerId, " +
+            "nickname='$nickname', " +
+            "profileImageUrl='$profileImageUrl', " +
+            "address=$address, " +
+            "agreement=$agreement, " +
+            "alertFrequencies=$alertFrequencies, " +
+            "isDeleted=$isDeleted)"
     }
 }

--- a/src/main/kotlin/com/deepromeet/atcha/user/domain/UserAppender.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/user/domain/UserAppender.kt
@@ -21,7 +21,8 @@ class UserAppender(
                 providerId = providerUserInfo.providerId,
                 profileImageUrl = providerUserInfo.profileImageUrl,
                 address = signUpInfo.getAddress(),
-                agreement = signUpInfo.getAgreement()
+                agreement = signUpInfo.getAgreement(),
+                alertFrequencies = signUpInfo.alertFrequencies.toMutableSet()
             )
         return userJpaRepository.save(user)
     }

--- a/src/main/kotlin/com/deepromeet/atcha/user/domain/UserUpdateInfo.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/user/domain/UserUpdateInfo.kt
@@ -7,5 +7,6 @@ data class UserUpdateInfo(
     val lat: Double?,
     val log: Double?,
     val alertAgreement: Boolean?,
-    val trackingAgreement: Boolean?
+    val trackingAgreement: Boolean?,
+    val alertFrequencies: Set<Int>?
 )

--- a/src/test/kotlin/com/deepromeet/atcha/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/com/deepromeet/atcha/auth/AuthServiceTest.kt
@@ -85,7 +85,7 @@ class AuthServiceTest {
         val profile = Profile("newUser", "new@test.com")
         val kakaoUserInfo = KakaoUserInfoResponse(kakaoId, KakaoAccount(profile))
         `when`(kakaoFeignClient.getUserInfo(anyString())).thenReturn(kakaoUserInfo)
-        val signUpRequest = SignUpInfo(0, "dummyValue", 37.123, 126.123, true, true)
+        val signUpRequest = SignUpInfo(0, "dummyValue", 37.123, 126.123, true, true, setOf(1, 10, 15))
 
         // when
         val result = authService.signUp(token, signUpRequest)
@@ -113,7 +113,7 @@ class AuthServiceTest {
                 profileImageUrl = kakaoUserInfo.profileImageUrl
             )
         userAppender.save(existingUser)
-        val signUpRequest = SignUpInfo(0, "dummyValue", 37.123, 126.123, true, true)
+        val signUpRequest = SignUpInfo(0, "dummyValue", 37.123, 126.123, true, true, setOf(1, 10, 15))
 
         // when & then
         assertThatThrownBy { authService.signUp(token, signUpRequest) }

--- a/src/test/kotlin/com/deepromeet/atcha/user/UserControllerTest.kt
+++ b/src/test/kotlin/com/deepromeet/atcha/user/UserControllerTest.kt
@@ -26,7 +26,13 @@ class UserControllerTest(
     private val userAppender: UserAppender
 ) : BaseControllerTest() {
     var accessToken: String = ""
-    var savedUser: User = User(providerId = 1L, nickname = "유저", profileImageUrl = "")
+    var savedUser: User =
+        User(
+            providerId = 1L,
+            nickname = "유저",
+            profileImageUrl = "유저 이미지",
+            alertFrequencies = mutableSetOf(1, 10, 20)
+        )
 
     @BeforeEach
     fun issueToken() {
@@ -56,6 +62,8 @@ class UserControllerTest(
         val userInfoUpdateRequest =
             UserInfoUpdateRequest(
                 "새로운 닉네임",
+                null,
+                null,
                 null,
                 null,
                 null,

--- a/src/test/kotlin/com/deepromeet/atcha/user/UserControllerTest.kt
+++ b/src/test/kotlin/com/deepromeet/atcha/user/UserControllerTest.kt
@@ -68,7 +68,6 @@ class UserControllerTest(
                 null,
                 null,
                 null,
-                null,
                 null
             )
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #32 

## 📝작업 내용

- 알림 빈도 추가

## 💬리뷰 요구사항(선택)
알림 빈도를 저장하기 위해 별도 엔티티를 추가하는 것이 `@ElementCollection`을 사용했습니다.
해당 부분에 대해 고민한 내용을 [노션](https://www.notion.so/depromeet/Entity-1ac45b4338b38017b5d9cb7a907c313b?pvs=4)에 정리해주었어요! 첨언 부탁드릴게요!