### PR TITLE
[#36] actions 버전 업그레이드

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -1,4 +1,4 @@
-name: Atcha Deploy with Docker
+name: [DEV CD] Atcha Deploy with Docker
 
 on:
   workflow_dispatch:
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2 # git 레파지토리를 클론하는것과 같음
+        uses: actions/checkout@v4 # git 레파지토리를 클론하는것과 같음
         with:
           submodules: true
           token: ${{ secrets.SUBMODULE_TOKEN }}
@@ -33,7 +33,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Cache docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ env.VERSION }}
@@ -41,7 +41,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Login to ghcr
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -49,7 +49,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #36 

## 📝작업 내용

- deprecated 된 actions 버전 때문에 CD가 실패해서 버전을 모두 업그레이드 해주었습니다.
<img width="738" alt="image" src="https://github.com/user-attachments/assets/1e46eb63-e5a4-4369-9faf-6e1f22e78184" />

(3월 1일부터 안된다고 하네요 ㅎㅎ 이번 기회에 다른 actions들도 최신으로 업데이트 했습니다.)
[[참고1]](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down)
[[참고2]](https://github.com/actions/toolkit/blob/main/packages/cache/README.md)
