### PR TITLE
[#42] 알림 및 위치 추적 동의 여부 삭제

### DIFF
--- a/src/main/kotlin/com/deepromeet/atcha/user/api/request/UserInfoUpdateRequest.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/user/api/request/UserInfoUpdateRequest.kt
@@ -8,8 +8,6 @@ data class UserInfoUpdateRequest(
     val address: String?,
     val lat: Double?,
     val log: Double?,
-    val alertAgreement: Boolean?,
-    val trackingAgreement: Boolean?,
     val alertFrequencies: Set<Int>?
 ) {
     fun toUpdateUserInfo(): UserUpdateInfo {
@@ -19,8 +17,6 @@ data class UserInfoUpdateRequest(
             address = address,
             lat = lat,
             log = log,
-            alertAgreement = alertAgreement,
-            trackingAgreement = trackingAgreement,
             alertFrequencies = alertFrequencies
         )
     }

--- a/src/main/kotlin/com/deepromeet/atcha/user/api/response/UserInfoResponse.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/user/api/response/UserInfoResponse.kt
@@ -10,8 +10,6 @@ data class UserInfoResponse(
     val address: String,
     val lat: Double,
     val lon: Double,
-    val alertAgreement: Boolean,
-    val trackingAgreement: Boolean,
     val alertFrequencies: Set<Int>
 ) {
     companion object {
@@ -24,8 +22,6 @@ data class UserInfoResponse(
                 domain.address.address,
                 domain.address.lat,
                 domain.address.lon,
-                domain.agreement.alert,
-                domain.agreement.tracking,
                 domain.alertFrequencies
             )
     }

--- a/src/main/kotlin/com/deepromeet/atcha/user/domain/UserAppender.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/user/domain/UserAppender.kt
@@ -38,8 +38,6 @@ class UserAppender(
         userUpdateInfo.lat?.let { user.address.lat = it }
         userUpdateInfo.log?.let { user.address.lon = it }
 
-        userUpdateInfo.alertAgreement?.let { user.agreement.alert = it }
-        userUpdateInfo.trackingAgreement?.let { user.agreement.tracking = it }
         return user
     }
 

--- a/src/main/kotlin/com/deepromeet/atcha/user/domain/UserUpdateInfo.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/user/domain/UserUpdateInfo.kt
@@ -6,7 +6,5 @@ data class UserUpdateInfo(
     val address: String?,
     val lat: Double?,
     val log: Double?,
-    val alertAgreement: Boolean?,
-    val trackingAgreement: Boolean?,
     val alertFrequencies: Set<Int>?
 )

--- a/src/test/kotlin/com/deepromeet/atcha/user/UserControllerTest.kt
+++ b/src/test/kotlin/com/deepromeet/atcha/user/UserControllerTest.kt
@@ -66,8 +66,6 @@ class UserControllerTest(
                 null,
                 null,
                 null,
-                null,
-                null,
                 null
             )
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #42 

## 📝작업 내용
알림 및 위치추적 동의 여부를 서버에서 저장하지 않기로 안드로이드와 협의했습니다.

동의여부는 기기에 따라 변경할 수 있어서 싱크가 안맞을 수 있다고 합니다. 따라서 서버는 동의여부와 상관없이 알림을 보내주고 기기에서 동의 여부에 따라 처리하기로 결정했습니다.
