### PR TITLE
[#44] 미동의 유저 기본 프로필 설정

### DIFF
--- a/src/main/kotlin/com/deepromeet/atcha/auth/infrastructure/response/KakaoUserInfoResponse.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/auth/infrastructure/response/KakaoUserInfoResponse.kt
@@ -9,16 +9,19 @@ data class KakaoUserInfoResponse(
     @JsonProperty("id") val kakaoId: Long,
     val kakaoAccount: KakaoAccount
 ) {
-    val nickname: String get() = kakaoAccount.profile.nickname
-    val profileImageUrl: String get() = kakaoAccount.profile.profileImageUrl
-    val profile: Profile get() = kakaoAccount.profile
+    val nickname: String
+        get() = kakaoAccount.profile.nickname
+    val profileImageUrl: String
+        get() = kakaoAccount.profile.profileImageUrl
+    val profile: Profile
+        get() = kakaoAccount.profile
 
     fun toUserInfoResponse(): ProviderUserInfoResponse =
         ProviderUserInfoResponse(providerId = kakaoId, nickname, profileImageUrl)
 }
 
 data class KakaoAccount(
-    val profile: Profile
+    val profile: Profile = Profile("익명", "")
 )
 
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #44 

## 📝작업 내용
카카오 로그인 사용자가 닉네임과 프로필 사진을 미동의한 경우 기본 닉네임을 설정합니다.


