### PR TITLE
[#66] 지하철역 ord 컬럼 제거

### DIFF
--- a/src/main/kotlin/com/deepromeet/atcha/transit/domain/SubwayStation.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/domain/SubwayStation.kt
@@ -10,8 +10,7 @@ class SubwayStation(
     val stationCode: String,
     val name: String,
     val routeName: String,
-    val routeCode: String,
-    val ord: Int
+    val routeCode: String
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -22,7 +21,6 @@ class SubwayStation(
         if (name != other.name) return false
         if (routeName != other.routeName) return false
         if (routeCode != other.routeCode) return false
-        if (ord != other.ord) return false
 
         return true
     }

--- a/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/public/KRICSubwayStationClient.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/public/KRICSubwayStationClient.kt
@@ -28,8 +28,7 @@ class KRICSubwayStationClient(
                         st.stinCd,
                         st.stinNm,
                         st.routNm,
-                        st.routCd,
-                        st.stinConsOrdr
+                        st.routCd
                     )
                 }
             }.awaitAll()


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #66

## 📝작업 내용

- 지하철역의 순서는 이제 subway_branch 엔티티에서 관리하기때문에 subway_station에서는 제거했습니다

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  -
