### PR TITLE
[#113] 엑세스 토큰 만료 시간 2달 설정

### DIFF
--- a/src/main/kotlin/com/deepromeet/atcha/common/token/TokenType.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/common/token/TokenType.kt
@@ -3,6 +3,6 @@ package com.deepromeet.atcha.common.token
 enum class TokenType(
     val expirationMills: Long
 ) {
-    ACCESS(1000L * 60 * 30), // 30분
-    REFRESH(1000L * 60 * 60 * 24 * 60) // 60일
+    ACCESS(1000L * 60 * 30 * 24 * 30 * 2), // 60일
+    REFRESH(1000L * 60 * 60 * 24 * 30 * 2) // 60일
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #113 

## 📝작업 내용
심사 과정동안 안정성을 위해 엑세스 토큰을 1시간에서 2달로 변경합니다. 추후 심사가 끝나면 다시 1시간으로 복구시킬 예정입니다!

