### PR TITLE
[#125] 서울 버스 운행정보 조회

### DIFF
--- a/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/public/PublicSeoulBusRouteInfoClient.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/public/PublicSeoulBusRouteInfoClient.kt
@@ -5,6 +5,7 @@ import com.deepromeet.atcha.transit.domain.BusRoute
 import com.deepromeet.atcha.transit.domain.BusRouteInfoClient
 import com.deepromeet.atcha.transit.domain.BusRouteOperationInfo
 import com.deepromeet.atcha.transit.domain.BusStation
+import com.deepromeet.atcha.transit.infrastructure.client.public.response.toBusRouteOperationInfo
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Component
 
@@ -13,7 +14,7 @@ private val log = KotlinLogging.logger {}
 @Component
 class PublicSeoulBusRouteInfoClient(
     private val publicSeoulBusArrivalInfoFeignClient: PublicSeoulBusArrivalInfoFeignClient,
-    private val publicSeoulBusRouteInfoFeignClient: PublicSeoulBusRouteInfoFeignClient
+    private val seoulBusOperationFeignClient: SeoulBusOperationFeignClient
 ) : BusRouteInfoClient {
     override fun getBusArrival(
         station: BusStation,
@@ -31,10 +32,6 @@ class PublicSeoulBusRouteInfoClient(
     }
 
     override fun getBusRouteInfo(route: BusRoute): BusRouteOperationInfo? {
-        return publicSeoulBusRouteInfoFeignClient.getRouteInfo(route.id.value)
-            .msgBody
-            .itemList
-            ?.get(0)
-            ?.toBusRouteOperationInfo()
+        return seoulBusOperationFeignClient.getBusOperationInfo(route.id.value).toBusRouteOperationInfo()
     }
 }

--- a/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/public/SeoulBusOperationFeignClient.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/public/SeoulBusOperationFeignClient.kt
@@ -1,0 +1,17 @@
+package com.deepromeet.atcha.transit.infrastructure.client.public
+
+import com.deepromeet.atcha.transit.infrastructure.client.public.response.SeoulBusOperationResponse
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+
+@FeignClient(
+    name = "public-seoul-bus-operation",
+    url = "\${open-api.api.url.bus-operation}"
+)
+interface SeoulBusOperationFeignClient {
+    @GetMapping
+    fun getBusOperationInfo(
+        @RequestParam routId: String
+    ): SeoulBusOperationResponse
+}

--- a/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/public/response/SeoulBusOperationResponse.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/public/response/SeoulBusOperationResponse.kt
@@ -1,0 +1,97 @@
+package com.deepromeet.atcha.transit.infrastructure.client.public.response
+
+import com.deepromeet.atcha.transit.domain.BusRouteOperationInfo
+import com.deepromeet.atcha.transit.domain.BusServiceHours
+import com.deepromeet.atcha.transit.domain.DailyType
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+data class SeoulBusOperationResponse(
+    val rows: List<SeoulBusOperationRow>
+)
+
+data class SeoulBusOperationRow(
+    val routId: String,
+    val routName: String,
+    val rtCd: Int,
+    val routType: String,
+    val tmpOrder: Int,
+    val stnFirst: String,
+    val stnLast: String,
+    val busIntervals: Int,
+    val timeFirst: String,
+    val timeLast: String,
+    val satTimeFirst: String,
+    val satTimeLast: String,
+    val holTimeFirst: String,
+    val holTimeLast: String,
+    val routeDistance: Int,
+    val busFee: Int,
+    val busRunStatusCd: String,
+    val busRunStatus: String?,
+    val turnPlaceStationId: String,
+    val normalDayFirstBusTime: String,
+    val normalDayLastBusTime: String,
+    val normalLastRouteAt: String,
+    val normalLastBusId: String,
+    val lowerDayFirstBusTime: String,
+    val lowerDayLastBusTime: String,
+    val lowerLastRouteAt: String,
+    val lowerLastBusId: String,
+    val timegap: Int,
+    val norTerms: String,
+    val satTerms: String,
+    val holTerms: String,
+    val routNo: String,
+    val companyNm: String,
+    val faxNo: String?,
+    val telNo: String,
+    val email: String?,
+    val etcDesc: String?,
+    val rn: Int,
+    val rnum: Int
+)
+
+private fun parseTime(hhmm: String): LocalDateTime {
+    val hour = hhmm.substring(0, 2).toIntOrNull() ?: 0
+    val minute = hhmm.substring(2, 4).toIntOrNull() ?: 0
+    val today = LocalDate.now()
+    return LocalDateTime.of(today, LocalTime.of(hour, minute))
+}
+
+fun SeoulBusOperationResponse.toBusRouteOperationInfo(): BusRouteOperationInfo? {
+    val row = rows.firstOrNull() ?: return null
+
+    val serviceHoursList = mutableListOf<BusServiceHours>()
+
+    serviceHoursList +=
+        BusServiceHours(
+            dailyType = DailyType.WEEKDAY,
+            startTime = parseTime(row.timeFirst),
+            endTime = parseTime(row.timeLast),
+            term = row.norTerms.toIntOrNull() ?: 0
+        )
+
+    serviceHoursList +=
+        BusServiceHours(
+            dailyType = DailyType.SATURDAY,
+            startTime = parseTime(row.satTimeFirst),
+            endTime = parseTime(row.satTimeLast),
+            term = row.satTerms.toIntOrNull() ?: 0
+        )
+
+    serviceHoursList +=
+        BusServiceHours(
+            dailyType = DailyType.HOLIDAY,
+            startTime = parseTime(row.holTimeFirst),
+            endTime = parseTime(row.holTimeLast),
+            term = row.holTerms.toIntOrNull() ?: 0
+        )
+
+    return BusRouteOperationInfo(
+        startStationName = row.stnFirst,
+        endStationName = row.stnLast,
+        serviceHours = serviceHoursList
+    )
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,7 @@ open-api:
       bus: http://ws.bus.go.kr
       bus-route: http://ws.bus.go.kr/api/rest/busRouteInfo
       bus-postion: http://ws.bus.go.kr/api/rest/buspos
+      bus-operation: https://topis.seoul.go.kr/map/busMap/selectBusList.do
       gyeonggi-bus: http://apis.data.go.kr/6410000/busstationservice/v2
       gyeonggi-route: http://apis.data.go.kr/6410000/busrouteservice/v2
       gyeonggi-arrival: http://apis.data.go.kr/6410000/busarrivalservice/v2


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #125 

## 📝작업 내용

- 기존 서울 버스 운행정보는 금일 정보만 제공되었지만 평일,토요일,공휴일 정보까지 제공하도록 변경

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  -
