### PR TITLE
[#136] 엑세스 토큰 만료 기간 30분으로 재설정

### DIFF
--- a/src/main/kotlin/com/deepromeet/atcha/common/token/TokenType.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/common/token/TokenType.kt
@@ -3,6 +3,6 @@ package com.deepromeet.atcha.common.token
 enum class TokenType(
     val expirationMills: Long
 ) {
-    ACCESS(1000L * 60 * 30 * 24 * 30 * 2), // 60일
+    ACCESS(1000L * 60 * 30), // 30분
     REFRESH(1000L * 60 * 60 * 24 * 30 * 2) // 60일
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #136 

## 📝작업 내용
- 심사를 위해 늘렸던 엑세스 만료 기간을 다시 30분으로 바꾼다

