### PR TITLE
[#140] 운영 환경 sql 로그 비활성화

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -7,6 +7,20 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+    properties:
+      hibernate:
+        show-sql: false
+        format_sql: false
+        default_batch_fetch_size: 100
+
+logging:
+  level:
+    org:
+      hibernate:
+        SQL: WARN
+        orm:
+          jdbc:
+            bind: WARN
 
 tmap:
   api:


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #140 

## 📝작업 내용
- 운영 환경에서는 sql 로그가 출력 안되도록 수정합니다.
   - 디버깅을 위한 용도로 sql 로그를 찍고 있었으므로 운영 환경에서는 불필요한 로그라고 생각합니다!


