### PR TITLE
[#227] TMAP 정류장 이름 뒤 (중) 제거

### DIFF
--- a/src/main/kotlin/com/deepromeet/atcha/transit/domain/BusStationMeta.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/domain/BusStationMeta.kt
@@ -7,6 +7,8 @@ data class BusStationMeta(
     val coordinate: Coordinate
 ) {
     fun resolveName(): String {
-        return name.replace("(지하)", "")
+        return name
+            .replace("(지하)", "")
+            .replace("(중)", "")
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #227 

## 📝작업 내용

- TMAP에서는 중앙 정류장 일 경우 정류장 이름 뒤에 (중)을 붙여서 주는데 이게 공공데이터에서는 (중)을 제거해야 나옴

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  -
