### PR TITLE
[#239] 로그아웃, 회원정보 수정 버그 수정

### DIFF
--- a/src/main/kotlin/com/deepromeet/atcha/auth/domain/AuthService.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/auth/domain/AuthService.kt
@@ -77,12 +77,6 @@ class AuthService(
     @Transactional
     fun logout(refreshToken: String) {
         tokenGenerator.validateToken(refreshToken, TokenType.REFRESH)
-        val userId = tokenGenerator.getUserIdByToken(refreshToken, TokenType.REFRESH)
-
-        val userProvider = userProviderReader.read(userId)
-        val authProvider = authProviders.getAuthProvider(userProvider.provider)
-        authProvider.logout(userProvider.provider)
-
         tokenGenerator.expireTokensWithRefreshToken(refreshToken)
     }
 

--- a/src/main/kotlin/com/deepromeet/atcha/common/logging/interceptor/DefaultLoggingInterceptor.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/common/logging/interceptor/DefaultLoggingInterceptor.kt
@@ -3,12 +3,10 @@ package com.deepromeet.atcha.common.logging.interceptor
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.MDC
-import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 import org.springframework.web.util.ContentCachingRequestWrapper
 
 @Component
-//@Profile("dev", "staging", "local", "test")
 class DefaultLoggingInterceptor : BaseLoggingInterceptor() {
     override fun afterCompletion(
         request: HttpServletRequest,

--- a/src/main/kotlin/com/deepromeet/atcha/common/logging/interceptor/DefaultLoggingInterceptor.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/common/logging/interceptor/DefaultLoggingInterceptor.kt
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component
 import org.springframework.web.util.ContentCachingRequestWrapper
 
 @Component
-@Profile("dev", "staging", "local", "test")
+//@Profile("dev", "staging", "local", "test")
 class DefaultLoggingInterceptor : BaseLoggingInterceptor() {
     override fun afterCompletion(
         request: HttpServletRequest,

--- a/src/main/kotlin/com/deepromeet/atcha/common/logging/interceptor/ProdLoggingInterceptor.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/common/logging/interceptor/ProdLoggingInterceptor.kt
@@ -6,8 +6,8 @@ import org.slf4j.MDC
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 
-@Component
-@Profile("prod")
+//@Component
+//@Profile("prod")
 class ProdLoggingInterceptor : BaseLoggingInterceptor() {
     override fun afterCompletion(
         request: HttpServletRequest,

--- a/src/main/kotlin/com/deepromeet/atcha/common/logging/interceptor/ProdLoggingInterceptor.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/common/logging/interceptor/ProdLoggingInterceptor.kt
@@ -3,11 +3,9 @@ package com.deepromeet.atcha.common.logging.interceptor
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.MDC
-import org.springframework.context.annotation.Profile
-import org.springframework.stereotype.Component
 
-//@Component
-//@Profile("prod")
+// @Component
+// @Profile("prod")
 class ProdLoggingInterceptor : BaseLoggingInterceptor() {
     override fun afterCompletion(
         request: HttpServletRequest,

--- a/src/main/kotlin/com/deepromeet/atcha/user/api/request/UserInfoUpdateRequest.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/user/api/request/UserInfoUpdateRequest.kt
@@ -7,7 +7,7 @@ data class UserInfoUpdateRequest(
     val profileImageUrl: String? = null,
     val address: String? = null,
     val lat: Double? = null,
-    val log: Double? = null,
+    val lon: Double? = null,
     val alertFrequencies: MutableSet<Int>? = null,
     val fcmToken: String? = null
 ) {
@@ -17,7 +17,7 @@ data class UserInfoUpdateRequest(
             profileImageUrl = profileImageUrl,
             address = address,
             lat = lat,
-            log = log,
+            lon = lon,
             alertFrequencies = alertFrequencies,
             fcmToken = fcmToken
         )

--- a/src/main/kotlin/com/deepromeet/atcha/user/domain/Address.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/user/domain/Address.kt
@@ -36,6 +36,4 @@ class Address(
         result = 31 * result + lon.hashCode()
         return result
     }
-
-
 }

--- a/src/main/kotlin/com/deepromeet/atcha/user/domain/Address.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/user/domain/Address.kt
@@ -16,4 +16,26 @@ class Address(
     fun resolveCoordinate(): Coordinate {
         return Coordinate(lat, lon)
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Address
+
+        if (address != other.address) return false
+        if (lat != other.lat) return false
+        if (lon != other.lon) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = address.hashCode()
+        result = 31 * result + lat.hashCode()
+        result = 31 * result + lon.hashCode()
+        return result
+    }
+
+
 }

--- a/src/main/kotlin/com/deepromeet/atcha/user/domain/UserAppender.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/user/domain/UserAppender.kt
@@ -36,7 +36,7 @@ class UserAppender(
         userUpdateInfo.alertFrequencies?.let { user.alertFrequencies = it }
         userUpdateInfo.address?.let { user.address.address = it }
         userUpdateInfo.lat?.let { user.address.lat = it }
-        userUpdateInfo.log?.let { user.address.lon = it }
+        userUpdateInfo.lon?.let { user.address.lon = it }
         userUpdateInfo.fcmToken?.let { user.fcmToken = it }
         return user
     }

--- a/src/main/kotlin/com/deepromeet/atcha/user/domain/UserUpdateInfo.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/user/domain/UserUpdateInfo.kt
@@ -5,7 +5,7 @@ data class UserUpdateInfo(
     val profileImageUrl: String?,
     val address: String?,
     val lat: Double?,
-    val log: Double?,
+    val lon: Double?,
     val alertFrequencies: MutableSet<Int>?,
     val fcmToken: String?
 )

--- a/src/test/kotlin/com/deepromeet/atcha/user/UserControllerTest.kt
+++ b/src/test/kotlin/com/deepromeet/atcha/user/UserControllerTest.kt
@@ -61,7 +61,15 @@ class UserControllerTest(
     fun `회원 정보 수정`() {
         // given
         val userInfoUpdateRequest =
-            UserInfoUpdateRequest("새로운 닉네임", alertFrequencies = mutableSetOf(2))
+            UserInfoUpdateRequest(
+                nickname = "새로운 닉네임",
+                alertFrequencies = mutableSetOf(2),
+                profileImageUrl = "new",
+                address = "new",
+                lat = 37.99,
+                lon = 127.99,
+                fcmToken = "new"
+            )
 
         // when
         RestAssured.given().log().all()
@@ -77,6 +85,11 @@ class UserControllerTest(
         // then
         assertThat(findUser.nickname).isEqualTo(userInfoUpdateRequest.nickname)
         assertThat(findUser.alertFrequencies).isEqualTo(userInfoUpdateRequest.alertFrequencies)
+        assertThat(findUser.profileImageUrl).isEqualTo(userInfoUpdateRequest.profileImageUrl)
+        assertThat(findUser.address.address).isEqualTo(userInfoUpdateRequest.address)
+        assertThat(findUser.address.lat).isEqualTo(userInfoUpdateRequest.lat)
+        assertThat(findUser.address.lon).isEqualTo(userInfoUpdateRequest.lon)
+        assertThat(findUser.fcmToken).isEqualTo(userInfoUpdateRequest.fcmToken)
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #239 

## 📝작업 내용
- 회원 정보 수정 시 경도 누락 수정
- 로그아웃 시 카카오 토큰 만료 버그 수정

