### PR TITLE
[#324] 버스 도착 임계값 3분에서 5분으로 조정 

### DIFF
--- a/src/main/kotlin/com/deepromeet/atcha/route/application/UserRouteDepartureTimeRefresher.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/application/UserRouteDepartureTimeRefresher.kt
@@ -11,7 +11,7 @@ import java.time.Duration
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-private const val BUS_ARRIVAL_THRESHOLD_MINUTES = 5
+private const val BUS_ARRIVAL_THRESHOLD_MINUTES = 3
 private const val FIXED_REFRESH_MINUTES = 20
 private const val BUFFER_SEC_SECONDS = 2 * 60L
 

--- a/src/main/kotlin/com/deepromeet/atcha/transit/domain/bus/BusRealTimeArrival.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/domain/bus/BusRealTimeArrival.kt
@@ -11,10 +11,9 @@ data class BusRealTimeArrival(
             realTimeInfoList
                 .mapNotNull { it.expectedArrivalTime }
                 .sorted()
-                .takeLast(1)
                 .toMutableList()
 
-        val base = baseArrivals.firstOrNull() ?: return emptyList()
+        val base = baseArrivals.lastOrNull() ?: return emptyList()
         repeat(2) { i ->
             baseArrivals += base.plusMinutes(busTerm.toLong() * (i + 1))
         }


### PR DESCRIPTION
막차 시간 관련 이슈로 인해 버스 도착 임계값을 기존 3분에서 5분으로 증가시켜
차 시간이 뒤로 밀리는 문제를 방지합니다.

## #️⃣연관된 이슈

- close #324 

## 📝작업 내용

-

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  -
