### PR TITLE
[#327] TokenGenerator를 책임별로 3개 클래스로 분리 

### DIFF
--- a/src/main/kotlin/com/deepromeet/atcha/shared/web/token/CurrentUserArgumentResolver.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/shared/web/token/CurrentUserArgumentResolver.kt
@@ -13,7 +13,8 @@ import org.springframework.web.method.support.ModelAndViewContainer
 
 @Component
 class CurrentUserArgumentResolver(
-    private val tokenGenerator: TokenGenerator
+    private val jwtTokeParser: JwtTokeParser,
+    private val tokenExpirationManager: TokenExpirationManager
 ) : HandlerMethodArgumentResolver {
     companion object {
         private const val TOKEN_TYPE = "Bearer "
@@ -40,7 +41,8 @@ class CurrentUserArgumentResolver(
             )
         }
         val token = authorization.substring(TOKEN_TYPE.length)
-        tokenGenerator.validateToken(token, TokenType.ACCESS)
-        return tokenGenerator.getUserIdByToken(token, TokenType.ACCESS)
+        tokenExpirationManager.validateNotExpired(token)
+        jwtTokeParser.validateToken(token, TokenType.ACCESS)
+        return jwtTokeParser.getUserId(token, TokenType.ACCESS)
     }
 }

--- a/src/main/kotlin/com/deepromeet/atcha/shared/web/token/JwtTokenGenerator.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/shared/web/token/JwtTokenGenerator.kt
@@ -1,0 +1,62 @@
+package com.deepromeet.atcha.shared.web.token
+
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.io.Decoders
+import io.jsonwebtoken.security.Keys
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.util.Date
+import java.util.UUID
+
+@Component
+class JwtTokenGenerator(
+    @Value("\${jwt.access.secret}")
+    private val accessSecret: String,
+    @Value("\${jwt.refresh.secret}")
+    private val refreshSecret: String,
+    @Value("\${jwt.access.expiration}")
+    private val accessExpiration: String,
+    @Value("\${jwt.refresh.expiration}")
+    private val refreshExpiration: String
+) {
+    private val tokenKeyMap =
+        mapOf(
+            TokenType.ACCESS to Keys.hmacShaKeyFor(Decoders.BASE64.decode(accessSecret)),
+            TokenType.REFRESH to Keys.hmacShaKeyFor(Decoders.BASE64.decode(refreshSecret))
+        )
+
+    fun generateTokens(userId: Long): TokenInfo {
+        val now = Date()
+        val accessToken = generateAccessToken(userId, now)
+        val refreshToken = generateRefreshToken(userId, now, accessToken)
+        return TokenInfo(accessToken, refreshToken)
+    }
+
+    private fun generateAccessToken(
+        userId: Long,
+        now: Date
+    ): String {
+        return Jwts.builder()
+            .setSubject(userId.toString())
+            .setIssuedAt(now)
+            .setId(UUID.randomUUID().toString())
+            .setExpiration(Date(now.time + accessExpiration.toLong()))
+            .signWith(tokenKeyMap.get(TokenType.ACCESS))
+            .compact()
+    }
+
+    private fun generateRefreshToken(
+        userId: Long,
+        now: Date,
+        accessToken: String
+    ): String {
+        return Jwts.builder()
+            .setSubject(userId.toString())
+            .setIssuedAt(now)
+            .claim(TokenType.ACCESS.name, accessToken)
+            .setId(UUID.randomUUID().toString())
+            .setExpiration(Date(now.time + refreshExpiration.toLong()))
+            .signWith(tokenKeyMap.get(TokenType.REFRESH))
+            .compact()
+    }
+}

--- a/src/main/kotlin/com/deepromeet/atcha/shared/web/token/TokenExpirationManager.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/shared/web/token/TokenExpirationManager.kt
@@ -1,0 +1,27 @@
+package com.deepromeet.atcha.shared.web.token
+
+import com.deepromeet.atcha.shared.web.token.exception.TokenError
+import com.deepromeet.atcha.shared.web.token.exception.TokenException
+import org.springframework.stereotype.Component
+
+@Component
+class TokenExpirationManager(
+    private val blacklist: TokenBlacklist,
+    private val jwtTokeParser: JwtTokeParser
+) {
+    fun expireTokensWithRefreshToken(refreshToken: String) {
+        val accessToken = jwtTokeParser.getAccessToken(refreshToken)
+        expireToken(accessToken)
+        expireToken(refreshToken)
+    }
+
+    fun expireToken(token: String) {
+        blacklist.add(token)
+    }
+
+    fun validateNotExpired(token: String) {
+        if (blacklist.contains(token)) {
+            throw TokenException.Companion.of(TokenError.EXPIRED_TOKEN, "이미 만료되거나 로그아웃된 토큰입니다")
+        }
+    }
+}

--- a/src/main/kotlin/com/deepromeet/atcha/shared/web/token/exception/TokenError.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/shared/web/token/exception/TokenError.kt
@@ -10,8 +10,8 @@ enum class TokenError(
     override val message: String,
     override val logLevel: LogLevel
 ) : BaseErrorType {
-    EXPIRED_TOKEN(400, "TOK_001", "만료된 토큰입니다.", LogLevel.WARN),
-    NOT_VALID_TOKEN(400, "TOK_002", "유효하지 않는 토큰입니다.", LogLevel.WARN)
+    EXPIRED_TOKEN(401, "TOK_001", "만료된 토큰입니다.", LogLevel.WARN),
+    NOT_VALID_TOKEN(401, "TOK_002", "유효하지 않는 토큰입니다.", LogLevel.WARN)
 }
 
 class TokenException(

--- a/src/test/kotlin/com/deepromeet/atcha/auth/AuthControllerTest.kt
+++ b/src/test/kotlin/com/deepromeet/atcha/auth/AuthControllerTest.kt
@@ -97,7 +97,7 @@ class AuthControllerTest : BaseControllerTest() {
             .header(HttpHeaders.AUTHORIZATION, "Bearer ${signUpResponse.accessToken}")
             .`when`().delete("/api/members/me")
             .then().log().all()
-            .statusCode(400)
+            .statusCode(401)
     }
 
     @Test
@@ -140,7 +140,7 @@ class AuthControllerTest : BaseControllerTest() {
             .header("Authorization", "Bearer ${signUpResponse.refreshToken}")
             .`when`().get("/api/auth/reissue")
             .then().log().all()
-            .statusCode(400)
+            .statusCode(401)
     }
 
     @Test

--- a/src/test/kotlin/com/deepromeet/atcha/auth/TokenGeneratorTest.kt
+++ b/src/test/kotlin/com/deepromeet/atcha/auth/TokenGeneratorTest.kt
@@ -1,7 +1,9 @@
 package com.deepromeet.atcha.auth
 
+import com.deepromeet.atcha.shared.web.token.JwtTokeParser
+import com.deepromeet.atcha.shared.web.token.JwtTokenGenerator
 import com.deepromeet.atcha.shared.web.token.TokenBlacklist
-import com.deepromeet.atcha.shared.web.token.TokenGenerator
+import com.deepromeet.atcha.shared.web.token.TokenExpirationManager
 import com.deepromeet.atcha.shared.web.token.TokenType
 import com.deepromeet.atcha.shared.web.token.exception.TokenException
 import io.jsonwebtoken.Jwts
@@ -23,24 +25,21 @@ class TokenGeneratorTest(
     private val refreshSecret = "dGVzdFJmZXNoU2VjcmV0S2V5asdVmFsdWUxMjM0NTY3OA=="
     private val accessExpiration = "1800000"
     private val refreshExpiration = "1800000"
-    private lateinit var tokenGenerator: TokenGenerator
+    private lateinit var jwtTokenGenerator: JwtTokenGenerator
+    private lateinit var jwtTokeParser: JwtTokeParser
+    private lateinit var tokenExpirationManager: TokenExpirationManager
 
     @BeforeEach
     fun setUpTokenGenerator() {
-        tokenGenerator =
-            TokenGenerator(
-                accessSecret,
-                refreshSecret,
-                accessExpiration,
-                refreshExpiration,
-                tokenBlacklist
-            )
+        jwtTokenGenerator = JwtTokenGenerator(accessSecret, refreshSecret, accessExpiration, refreshExpiration)
+        jwtTokeParser = JwtTokeParser(accessSecret, refreshSecret)
+        tokenExpirationManager = TokenExpirationManager(tokenBlacklist, jwtTokeParser)
     }
 
     @Test
     fun `토큰 생성 테스트 - 생성된 토큰의 subject가 userId와 일치해야 한다`() {
         val userId = 100L
-        val tokenInfo = tokenGenerator.generateTokens(userId)
+        val tokenInfo = jwtTokenGenerator.generateTokens(userId)
 
         // 토큰이 빈 문자열이 아닌지 확인
         assert(tokenInfo.accessToken.isNotEmpty()) { "Access token should not be empty" }
@@ -56,7 +55,7 @@ class TokenGeneratorTest(
                 .body
         assertEquals(userId.toString(), accessClaims.subject, "Access token의 subject는 userId와 일치해야 합니다.")
         Assertions.assertThatNoException()
-            .isThrownBy { tokenGenerator.validateToken(tokenInfo.accessToken, TokenType.ACCESS) }
+            .isThrownBy { jwtTokeParser.validateToken(tokenInfo.accessToken, TokenType.ACCESS) }
 
         // refreshToken 확인
         val refreshKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(refreshSecret))
@@ -68,20 +67,20 @@ class TokenGeneratorTest(
                 .body
         assertEquals(userId.toString(), refreshClaims.subject, "Refresh token의 subject는 userId와 일치해야 합니다.")
         Assertions.assertThatNoException()
-            .isThrownBy { tokenGenerator.validateToken(tokenInfo.refreshToken, TokenType.REFRESH) }
+            .isThrownBy { jwtTokeParser.validateToken(tokenInfo.refreshToken, TokenType.REFRESH) }
     }
 
     @Test
     fun `만료된 토큰 사용지 에러가 발생한다`() {
         // given
         val userId = 100L
-        val tokenInfo = tokenGenerator.generateTokens(userId)
+        val tokenInfo = jwtTokenGenerator.generateTokens(userId)
 
         // when
-        tokenGenerator.expireToken(tokenInfo.accessToken)
+        tokenExpirationManager.expireToken(tokenInfo.accessToken)
 
         // then
-        Assertions.assertThatThrownBy { tokenGenerator.validateToken(tokenInfo.accessToken, TokenType.ACCESS) }
+        Assertions.assertThatThrownBy { tokenExpirationManager.validateNotExpired(tokenInfo.accessToken) }
             .isInstanceOf(TokenException::class.java)
     }
 }

--- a/src/test/kotlin/com/deepromeet/atcha/user/UserControllerTest.kt
+++ b/src/test/kotlin/com/deepromeet/atcha/user/UserControllerTest.kt
@@ -2,7 +2,7 @@ package com.deepromeet.atcha.user
 
 import com.deepromeet.atcha.app.application.AppVersionAppender
 import com.deepromeet.atcha.shared.web.ApiResponse
-import com.deepromeet.atcha.shared.web.token.TokenGenerator
+import com.deepromeet.atcha.shared.web.token.JwtTokenGenerator
 import com.deepromeet.atcha.support.BaseControllerTest
 import com.deepromeet.atcha.support.fixture.UserFixture
 import com.deepromeet.atcha.user.api.request.UserInfoUpdateRequest
@@ -23,7 +23,7 @@ import org.springframework.http.HttpHeaders
 
 class UserControllerTest(
     @Autowired
-    private val tokenGenerator: TokenGenerator,
+    private val jwtTokenGenerator: JwtTokenGenerator,
     @Autowired
     private val userReader: UserReader,
     @Autowired
@@ -37,7 +37,7 @@ class UserControllerTest(
     @BeforeEach
     fun issueToken() {
         user = userAppender.append(user)
-        val generateToken = tokenGenerator.generateTokens(user.id)
+        val generateToken = jwtTokenGenerator.generateTokens(user.id)
         accessToken = generateToken.accessToken
         appVersionAppender.createAppVersion("test v1.0.0")
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #327

## 📝작업 내용

- JwtTokenGenerator: 토큰 생성 전용 클래스
- JwtTokeParser: 토큰 검증 및 파싱 전용 클래스
- TokenExpirationManager: 토큰 만료 관리 전용 클래스
- AuthService, CurrentUserArgumentResolver에서 새로운 클래스들 사용
- 토큰 만료 시 HTTP 상태코드를 400에서 401로 변경
- 테스트 코드 업데이트 및 검증 완료


## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  -
