### PR TITLE
hotfix: 운영 환경 JPA DDL 모드를 none으로 변경

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     properties:
       hibernate:
         show-sql: false


### PR DESCRIPTION
운영 환경에서 데이터베이스 스키마 자동 변경을 비활성화하여
안전성을 향상시킵니다.

## #️⃣연관된 이슈

- close #

## 📝작업 내용

-

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  -
