### PR TITLE
[#350] 막차 경로 탐색 안정성 개선

### DIFF
--- a/src/main/kotlin/com/deepromeet/atcha/route/application/LastRouteCalculator.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/application/LastRouteCalculator.kt
@@ -2,6 +2,7 @@ package com.deepromeet.atcha.route.application
 
 import com.deepromeet.atcha.location.domain.Coordinate
 import com.deepromeet.atcha.route.domain.LastRoute
+import com.deepromeet.atcha.route.domain.LastRouteTimeAdjuster
 import com.deepromeet.atcha.route.domain.RouteItinerary
 import com.deepromeet.atcha.route.exception.RouteError
 import com.deepromeet.atcha.route.exception.RouteException
@@ -17,6 +18,7 @@ import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import org.springframework.stereotype.Component
+import java.time.LocalDateTime
 import java.util.Collections
 
 private val log = KotlinLogging.logger {}
@@ -78,7 +80,9 @@ class LastRouteCalculator(
 
                     if (route != null) {
                         lastRouteBuffer.add(route)
-                        send(route)
+                        if (route.parseDepartureTime().isAfter(LocalDateTime.now())) {
+                            send(route)
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/com/deepromeet/atcha/route/application/UserRouteDepartureTimeRefresher.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/application/UserRouteDepartureTimeRefresher.kt
@@ -39,7 +39,7 @@ class UserRouteDepartureTimeRefresher(
 
         // 1) 버스 구간 및 시간표 추출
         val firstBusLeg = extractFirstBusTransit(route) ?: return null
-        val busInfo = firstBusLeg.busInfo ?: return null
+        val busInfo = firstBusLeg.requireBusInfo()
 
         // "20분 + 배차 간격" 윈도우 내에서만 갱신 시도 (현재 계획 기준)
         if (isNotRefreshTarget(userRoute.parseUpdatedDepartureTime(), busInfo.timeTable.term)) {

--- a/src/main/kotlin/com/deepromeet/atcha/route/domain/LastRoute.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/domain/LastRoute.kt
@@ -52,7 +52,9 @@ data class LastRoute(
             itinerary: RouteItinerary,
             adjustedLegs: List<LastRouteLeg>
         ): LastRoute {
-            val departureDateTime = calculateDepartureTime(adjustedLegs)
+            val departureDateTime =
+                calculateDepartureTime(adjustedLegs)
+                    .validateLastRouteDeparture()
             val arrivalTime = calculateArrivalTime(adjustedLegs)
             val totalTime = Duration.between(departureDateTime, arrivalTime).seconds
 

--- a/src/main/kotlin/com/deepromeet/atcha/route/domain/LastRouteLeg.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/domain/LastRouteLeg.kt
@@ -102,7 +102,12 @@ data class LastRouteLeg(
     }
 
     private fun validateDepartureDateTime() {
-        require(!isValidRange(parseDepartureDateTime()))
+        if (isTransit()) {
+            val departureDateTime = parseDepartureDateTime()
+            require(isValidRange(departureDateTime)) {
+                "유효하지않은 막차 시간 범위입니다. 입력값: $departureDateTime, 노선: $route"
+            }
+        }
     }
 
     private fun validateRouteMode() {

--- a/src/main/kotlin/com/deepromeet/atcha/route/domain/LastRouteLeg.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/domain/LastRouteLeg.kt
@@ -7,7 +7,6 @@ import com.deepromeet.atcha.transit.domain.bus.BusStationMeta
 import com.deepromeet.atcha.transit.exception.TransitError
 import com.deepromeet.atcha.transit.exception.TransitException
 import java.time.LocalDateTime
-import java.time.LocalTime
 
 data class LastRouteLeg(
     val distance: Int,
@@ -25,7 +24,6 @@ data class LastRouteLeg(
     val transitInfo: TransitInfo
 ) {
     init {
-        validateDepartureDateTime()
         validateRouteMode()
         validateTransitDepartureTime()
     }
@@ -101,15 +99,6 @@ data class LastRouteLeg(
         return LocalDateTime.parse(departureDateTime!!)
     }
 
-    private fun validateDepartureDateTime() {
-        if (isTransit()) {
-            val departureDateTime = parseDepartureDateTime()
-            require(isValidRange(departureDateTime)) {
-                "유효하지않은 막차 시간 범위입니다. 입력값: $departureDateTime, 노선: $route"
-            }
-        }
-    }
-
     private fun validateRouteMode() {
         require(mode.isSupported) {
             "지원하지 않는 교통수단입니다: $mode"
@@ -122,13 +111,5 @@ data class LastRouteLeg(
                 "대중교통($mode)의 출발시간은 필수입니다"
             }
         }
-    }
-
-    private fun isValidRange(lastTime: LocalDateTime): Boolean {
-        val time = lastTime.toLocalTime()
-        val start = LocalTime.of(20, 0)
-        val end = LocalTime.of(3, 0)
-
-        return time.isAfter(start) || time.isBefore(end)
     }
 }

--- a/src/main/kotlin/com/deepromeet/atcha/route/domain/LastRouteLeg.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/domain/LastRouteLeg.kt
@@ -7,6 +7,7 @@ import com.deepromeet.atcha.transit.domain.bus.BusStationMeta
 import com.deepromeet.atcha.transit.exception.TransitError
 import com.deepromeet.atcha.transit.exception.TransitException
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 data class LastRouteLeg(
     val distance: Int,
@@ -24,6 +25,7 @@ data class LastRouteLeg(
     val transitInfo: TransitInfo
 ) {
     init {
+        validateDepartureDateTime()
         validateRouteMode()
         validateTransitDepartureTime()
     }
@@ -33,6 +35,14 @@ data class LastRouteLeg(
 
     val subwayInfo: TransitInfo.SubwayInfo?
         get() = transitInfo as? TransitInfo.SubwayInfo?
+
+    fun requireBusInfo(): TransitInfo.BusInfo {
+        return busInfo ?: throw IllegalStateException("버스 경로는 버스 정보가 필수입니다.")
+    }
+
+    fun requireSubwayInfo(): TransitInfo.SubwayInfo {
+        return subwayInfo ?: throw IllegalStateException("지하철 경로는 지하철 정보가 필수입니다.")
+    }
 
     fun isTransit(): Boolean = mode.isTransit()
 
@@ -91,6 +101,10 @@ data class LastRouteLeg(
         return LocalDateTime.parse(departureDateTime!!)
     }
 
+    private fun validateDepartureDateTime() {
+        require(!isValidRange(parseDepartureDateTime()))
+    }
+
     private fun validateRouteMode() {
         require(mode.isSupported) {
             "지원하지 않는 교통수단입니다: $mode"
@@ -103,5 +117,13 @@ data class LastRouteLeg(
                 "대중교통($mode)의 출발시간은 필수입니다"
             }
         }
+    }
+
+    private fun isValidRange(lastTime: LocalDateTime): Boolean {
+        val time = lastTime.toLocalTime()
+        val start = LocalTime.of(20, 0)
+        val end = LocalTime.of(3, 0)
+
+        return time.isAfter(start) || time.isBefore(end)
     }
 }

--- a/src/main/kotlin/com/deepromeet/atcha/route/domain/LastRouteTimeAdjuster.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/domain/LastRouteTimeAdjuster.kt
@@ -74,16 +74,28 @@ class LastRouteTimeAdjuster {
 
         for (i in adjustedLegs.indices) {
             val leg = adjustedLegs[i]
-            if (leg.isBus() && leg.departureDateTime != null) {
+            if (leg.isBus()) {
                 // 첫 번째 대중교통이 버스이고 현재 leg가 그 첫 번째 버스라면 건너뛰기
                 if (isFirstTransitBus && i == firstTransitIndex) continue
 
                 val busInfo = leg.requireBusInfo()
-                val currentTime = LocalDateTime.parse(leg.departureDateTime)
-                val adjustedTime = currentTime.minusMinutes(busInfo.timeTable.term.toLong())
+                val lastBusTime = leg.parseDepartureDateTime()
+                val prevLastBusTime = lastBusTime.minusMinutes(busInfo.timeTable.term.toLong())
+
+                val adjustedBusInfo =
+                    busInfo.copy(
+                        timeTable =
+                            busInfo.timeTable.copy(
+                                lastTime = prevLastBusTime
+                            )
+                    )
+
                 adjustedLegs[i] =
                     leg.copy(
-                        departureDateTime = adjustedTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"))
+                        departureDateTime =
+                            prevLastBusTime
+                                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")),
+                        transitInfo = adjustedBusInfo
                     )
             }
         }

--- a/src/main/kotlin/com/deepromeet/atcha/route/domain/LastRouteTimeAdjuster.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/domain/LastRouteTimeAdjuster.kt
@@ -1,6 +1,5 @@
-package com.deepromeet.atcha.route.application
+package com.deepromeet.atcha.route.domain
 
-import com.deepromeet.atcha.route.domain.LastRouteLeg
 import com.deepromeet.atcha.transit.domain.TimeDirection
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
@@ -11,6 +10,9 @@ import java.time.temporal.ChronoUnit
 class LastRouteTimeAdjuster {
     suspend fun adjustTransitDepartureTimes(legs: List<LastRouteLeg>): List<LastRouteLeg> {
         val adjustedLegs = legs.toMutableList()
+
+        // 첫 번째 대중교통이 버스인 경우를 제외하고 모든 버스의 출발시간을 배차간격만큼 빼기
+        adjustBusDepartureTimes(adjustedLegs)
 
         val transitLegs = adjustedLegs.withIndex().filter { it.value.isTransit() }
         if (transitLegs.isEmpty()) return adjustedLegs
@@ -64,6 +66,27 @@ class LastRouteTimeAdjuster {
         adjustLegsAfterBase(adjustedLegs, adjustBaseIndex)
 
         return adjustedLegs
+    }
+
+    private fun adjustBusDepartureTimes(adjustedLegs: MutableList<LastRouteLeg>) {
+        val firstTransitIndex = adjustedLegs.indexOfFirst { it.isTransit() }
+        val isFirstTransitBus = firstTransitIndex != -1 && adjustedLegs[firstTransitIndex].isBus()
+
+        for (i in adjustedLegs.indices) {
+            val leg = adjustedLegs[i]
+            if (leg.isBus() && leg.departureDateTime != null) {
+                // 첫 번째 대중교통이 버스이고 현재 leg가 그 첫 번째 버스라면 건너뛰기
+                if (isFirstTransitBus && i == firstTransitIndex) continue
+
+                val busInfo = leg.requireBusInfo()
+                val currentTime = LocalDateTime.parse(leg.departureDateTime)
+                val adjustedTime = currentTime.minusMinutes(busInfo.timeTable.term.toLong())
+                adjustedLegs[i] =
+                    leg.copy(
+                        departureDateTime = adjustedTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"))
+                    )
+            }
+        }
     }
 
     private suspend fun adjustLegsBeforeBase(

--- a/src/main/kotlin/com/deepromeet/atcha/route/domain/LastRouteValidation.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/domain/LastRouteValidation.kt
@@ -1,0 +1,12 @@
+package com.deepromeet.atcha.route.domain
+
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+fun LocalDateTime.validateLastRouteDeparture(): LocalDateTime {
+    val time = this.toLocalTime()
+    require(time.isAfter(LocalTime.of(20, 0)) || time.isBefore(LocalTime.of(3, 0))) {
+        "유효하지않은 막차 시간 범위입니다. 입력값: $this"
+    }
+    return this
+}

--- a/src/main/kotlin/com/deepromeet/atcha/route/exception/RouteError.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/exception/RouteError.kt
@@ -15,7 +15,8 @@ enum class RouteError(
     INVALID_LAST_ROUTE(500, "LRT_001", "유효하지 않은 막차 경로입니다.", LogLevel.ERROR),
     INVALID_ROUTE_MODE(500, "LRT_002", "지원하지 않는 모드입니다.", LogLevel.ERROR),
     LAST_ROUTES_NOT_FOUND(404, "LRT_003", "유효한 막차 경로를 찾을 수 없습니다.", LogLevel.WARN),
-    NO_AVAILABLE_LAST_ROUTES(404, "LRT_004", "시간이 늦어서 탑승 가능한 막차 경로가 없습니다.", LogLevel.WARN)
+    NO_AVAILABLE_LAST_ROUTES(404, "LRT_004", "시간이 늦어서 탑승 가능한 막차 경로가 없습니다.", LogLevel.WARN),
+    INVALID_LAST_TIME(500, "LRT_005", "04:00 ~ 20:00 사이의 시간은 유효하지 않습니다.", LogLevel.WARN)
 }
 
 class RouteException(

--- a/src/main/kotlin/com/deepromeet/atcha/transit/application/bus/BusManager.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/application/bus/BusManager.kt
@@ -34,6 +34,10 @@ class BusManager(
         busTimeTableCache.get(routeName, stationMeta)?.let { return it }
         val busRouteInfo = busRouteResolver.resolve(routeName, stationMeta, passStops)
 
+        if (routeName == "282") {
+            print("")
+        }
+
         val schedule =
             busScheduleProvider.getBusSchedule(busRouteInfo)
                 ?: throw TransitException.of(

--- a/src/main/kotlin/com/deepromeet/atcha/transit/domain/bus/BusTimeTable.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/domain/bus/BusTimeTable.kt
@@ -10,13 +10,15 @@ data class BusTimeTable(
     val lastTime: LocalDateTime,
     val term: Int
 ) {
+    init {
+        require(firstTime <= lastTime) { "첫차 시각($firstTime)이 막차 시각($lastTime)보다 늦습니다." }
+    }
+
     fun calculateNearestTime(
         time: LocalDateTime,
         timeDirection: TimeDirection
     ): LocalDateTime {
         require(term > 0) { "잘못된 배차 간격(term=$term)입니다. 0보다 커야 합니다." }
-        require(lastTime.isAfter(firstTime)) { "첫차 시각($firstTime)이 막차 시각($lastTime)보다 늦습니다." }
-
         return when (timeDirection) {
             TimeDirection.BEFORE -> {
                 if (time.isBefore(firstTime)) {

--- a/src/main/kotlin/com/deepromeet/atcha/transit/exception/TransitError.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/exception/TransitError.kt
@@ -30,6 +30,7 @@ enum class TransitError(
     INVALID_DIRECTION_NAME(400, "TRS_021", "유효하지 않은 지하철 방향 이름입니다.", LogLevel.ERROR),
     NOT_FOUND_SPECIFIED_TIME(404, "TRS_023", "특정 시간에 해당하는 대중교통을 찾을 수 없습니다.", LogLevel.ERROR),
     INVALID_TIME_FORMAT(400, "TRS_024", "유효하지 않은 시간 형식입니다.", LogLevel.ERROR),
+    BUS_TERM_REQUIRED(404, "TRS_026", "버스 배차간격은 필수 값입니다.", LogLevel.ERROR),
     API_TIME_OUT(500, "TRS_025", "TMap이 응답하지 않습니다.", LogLevel.ERROR)
 }
 

--- a/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/odsay/ODSayBusInfoClient.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/odsay/ODSayBusInfoClient.kt
@@ -5,8 +5,6 @@ import com.deepromeet.atcha.transit.domain.bus.BusSchedule
 import com.deepromeet.atcha.transit.exception.TransitError
 import com.deepromeet.atcha.transit.exception.TransitException
 import com.deepromeet.atcha.transit.infrastructure.client.public.common.utils.ApiClientUtils
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.springframework.stereotype.Component
 
 @Component
@@ -14,43 +12,42 @@ class ODSayBusInfoClient(
     private val oDSayBusFeignClient: ODSayBusFeignClient,
     private val oDSayCallCounter: ODSayCallCounter
 ) {
-    suspend fun getBusSchedule(routeInfo: BusRouteInfo): BusSchedule =
-        withContext(Dispatchers.IO) {
-            val busStation =
-                ApiClientUtils.callApiByKeyProvider(
-                    keyProvider = oDSayCallCounter::getApiKeyBasedOnUsage,
-                    apiCall = {
-                            key ->
-                        oDSayBusFeignClient.getStationByStationName(
-                            key,
-                            routeInfo.getTargetStation().stationName
+    suspend fun getBusSchedule(routeInfo: BusRouteInfo): BusSchedule {
+        val busStation =
+            ApiClientUtils.callApiByKeyProvider(
+                keyProvider = oDSayCallCounter::getApiKeyBasedOnUsage,
+                apiCall = {
+                        key ->
+                    oDSayBusFeignClient.getStationByStationName(
+                        key,
+                        routeInfo.getTargetStation().stationName
+                    )
+                },
+                processResult = { response ->
+                    response.result.station
+                        .find { it.arsID.trim() == routeInfo.getTargetStation().stationNumber.trim() }
+                        ?: throw TransitException.of(
+                            TransitError.NOT_FOUND_BUS_STATION,
+                            "ODSay에서 정류장 '${routeInfo.getTargetStation().stationName}'을 찾을 수 없습니다."
                         )
-                    },
-                    processResult = { response ->
-                        response.result.station
-                            .find { it.arsID.trim() == routeInfo.getTargetStation().stationNumber.trim() }
-                            ?: throw TransitException.of(
-                                TransitError.NOT_FOUND_BUS_STATION,
-                                "ODSay에서 정류장 '${routeInfo.getTargetStation().stationName}'을 찾을 수 없습니다."
-                            )
-                    },
-                    errorMessage = "ODSay에서 정류장 정보를 가져오는데 실패했습니다."
-                )
+                },
+                errorMessage = "ODSay에서 정류장 정보를 가져오는데 실패했습니다."
+            )
 
-            val busStationResponse =
-                ApiClientUtils.callApiByKeyProvider(
-                    keyProvider = oDSayCallCounter::getApiKeyBasedOnUsage,
-                    apiCall = { key -> oDSayBusFeignClient.getStationInfoByStationID(key, busStation.stationID) },
-                    processResult = { response ->
-                        response.result.lane.find { it.busLocalBlID == routeInfo.routeId }
-                            ?: throw TransitException.of(
-                                TransitError.NOT_FOUND_BUS_ROUTE,
-                                "ODSay에서 노선 '${routeInfo.route.name} - ${routeInfo.routeId}'을 찾을 수 없습니다."
-                            )
-                    },
-                    errorMessage = "ODSay에서 정류장 정보를 가져오는데 실패했습니다."
-                )
+        val busStationResponse =
+            ApiClientUtils.callApiByKeyProvider(
+                keyProvider = oDSayCallCounter::getApiKeyBasedOnUsage,
+                apiCall = { key -> oDSayBusFeignClient.getStationInfoByStationID(key, busStation.stationID) },
+                processResult = { response ->
+                    response.result.lane.find { it.busLocalBlID == routeInfo.routeId }
+                        ?: throw TransitException.of(
+                            TransitError.NOT_FOUND_BUS_ROUTE,
+                            "ODSay에서 노선 '${routeInfo.route.name} - ${routeInfo.routeId}'을 찾을 수 없습니다."
+                        )
+                },
+                errorMessage = "ODSay에서 정류장 정보를 가져오는데 실패했습니다."
+            )
 
-            busStationResponse.toBusSchedule(routeInfo.getTargetStation().busStation)
-        }
+        return busStationResponse.toBusSchedule(routeInfo.getTargetStation().busStation)
+    }
 }

--- a/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/odsay/response/ODSayBusResponse.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/odsay/response/ODSayBusResponse.kt
@@ -9,6 +9,7 @@ import com.deepromeet.atcha.transit.domain.region.ServiceRegion
 import com.deepromeet.atcha.transit.exception.TransitError
 import com.deepromeet.atcha.transit.exception.TransitException
 import java.lang.Exception
+import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -79,9 +80,39 @@ data class ODSayLaneResponse(
                 BusTimeTable(
                     parseTime(busFirstTime, LocalDate.now()),
                     parseTime(busLastTime, LocalDate.now()),
-                    busInterval.toInt()
+                    parseIntervalFromString(busInterval)
                 )
         )
+    }
+
+    private fun parseIntervalFromString(intervalStr: String): Int {
+        return try {
+            when {
+                intervalStr.endsWith("회") -> {
+                    // 운행횟수로 온 경우 배차간격으로 변환
+                    val operationCount = intervalStr.removeSuffix("회").toInt()
+                    calculateIntervalFromOperationCount(operationCount)
+                }
+                else -> {
+                    intervalStr.toInt()
+                }
+            }
+        } catch (e: NumberFormatException) {
+            throw TransitException.of(TransitError.INVALID_TIME_FORMAT)
+        }
+    }
+
+    private fun calculateIntervalFromOperationCount(operationCount: Int): Int {
+        if (operationCount <= 1) return 0
+
+        val referenceDate = LocalDate.now()
+        val firstDateTime = parseTime(busFirstTime, referenceDate)
+        val lastDateTime = parseTime(busLastTime, referenceDate)
+
+        val totalMinutes = Duration.between(firstDateTime, lastDateTime).toMinutes()
+
+        // 운행횟수 - 1로 나누는 이유: 첫차와 막차 사이의 간격 개수
+        return (totalMinutes / (operationCount - 1)).toInt()
     }
 
     fun parseTime(

--- a/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/public/gyeonggi/PublicGyeonggiBusPositionClient.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/public/gyeonggi/PublicGyeonggiBusPositionClient.kt
@@ -5,8 +5,6 @@ import com.deepromeet.atcha.transit.domain.bus.BusPosition
 import com.deepromeet.atcha.transit.domain.bus.BusRouteId
 import com.deepromeet.atcha.transit.infrastructure.client.public.common.utils.ApiClientUtils
 import com.deepromeet.atcha.transit.infrastructure.client.public.common.utils.ApiClientUtils.isGyeonggiApiLimitExceeded
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
@@ -21,19 +19,17 @@ class PublicGyeonggiBusPositionClient(
     private val realLastKey: String
 ) : BusPositionFetcher {
     override suspend fun fetch(routeId: BusRouteId): List<BusPosition> =
-        withContext(Dispatchers.IO) {
-            ApiClientUtils.callApiWithRetry(
-                primaryKey = serviceKey,
-                spareKey = spareKey,
-                realLastKey = realLastKey,
-                apiCall = { key -> publicGyeonggiBusPositionClient.getBusLocationList(key, routeId.value) },
-                isLimitExceeded = { response -> isGyeonggiApiLimitExceeded(response) },
-                processResult = { response ->
-                    response.msgBody?.busLocationList
-                        ?.map { it.toBusPosition() }
-                        ?: emptyList()
-                },
-                errorMessage = "경기도 버스 '${routeId.value}'의 버스 위치 정보를 가져오는 데 실패했습니다."
-            )
-        }
+        ApiClientUtils.callApiWithRetry(
+            primaryKey = serviceKey,
+            spareKey = spareKey,
+            realLastKey = realLastKey,
+            apiCall = { key -> publicGyeonggiBusPositionClient.getBusLocationList(key, routeId.value) },
+            isLimitExceeded = { response -> isGyeonggiApiLimitExceeded(response) },
+            processResult = { response ->
+                response.msgBody?.busLocationList
+                    ?.map { it.toBusPosition() }
+                    ?: emptyList()
+            },
+            errorMessage = "경기도 버스 '${routeId.value}'의 버스 위치 정보를 가져오는 데 실패했습니다."
+        )
 }

--- a/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/public/gyeonggi/PublicGyeonggiRouteInfoClient.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/public/gyeonggi/PublicGyeonggiRouteInfoClient.kt
@@ -12,8 +12,6 @@ import com.deepromeet.atcha.transit.domain.bus.BusSchedule
 import com.deepromeet.atcha.transit.exception.TransitError
 import com.deepromeet.atcha.transit.exception.TransitException
 import com.deepromeet.atcha.transit.infrastructure.client.public.common.utils.ApiClientUtils
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Component
@@ -37,68 +35,63 @@ class PublicGyeonggiRouteInfoClient(
         cacheManager = "apiCacheManager"
     )
     override suspend fun getBusRoute(routeName: String): List<BusRoute> =
-        withContext(Dispatchers.IO) {
-            ApiClientUtils.callApiWithRetry(
-                primaryKey = serviceKey,
-                spareKey = spareKey,
-                realLastKey = realLastKey,
-                apiCall = { key ->
-                    publicGyeonggiRouteInfoFeignClient.getRouteList(key, routeName)
-                },
-                isLimitExceeded = ApiClientUtils::isGyeonggiApiLimitExceeded,
-                processResult = { resp ->
-                    resp.msgBody?.busRouteList
-                        ?.filter { it.routeName == routeName }
-                        ?.map { it.toBusRoute() }
-                        ?.takeIf { it.isNotEmpty() }
-                        ?: throw TransitException.of(
-                            TransitError.NOT_FOUND_BUS_ROUTE,
-                            "경기도 버스 노선 '$routeName' 정보를 찾을 수 없습니다."
-                        )
-                },
-                errorMessage = "경기도 버스 노선 정보를 가져오는데 실패했습니다. $routeName"
-            )
-        }
+        ApiClientUtils.callApiWithRetry(
+            primaryKey = serviceKey,
+            spareKey = spareKey,
+            realLastKey = realLastKey,
+            apiCall = { key ->
+                publicGyeonggiRouteInfoFeignClient.getRouteList(key, routeName)
+            },
+            isLimitExceeded = ApiClientUtils::isGyeonggiApiLimitExceeded,
+            processResult = { resp ->
+                resp.msgBody?.busRouteList
+                    ?.filter { it.routeName == routeName }
+                    ?.map { it.toBusRoute() }
+                    ?.takeIf { it.isNotEmpty() }
+                    ?: throw TransitException.of(
+                        TransitError.NOT_FOUND_BUS_ROUTE,
+                        "경기도 버스 노선 '$routeName' 정보를 찾을 수 없습니다."
+                    )
+            },
+            errorMessage = "경기도 버스 노선 정보를 가져오는데 실패했습니다. $routeName"
+        )
 
-    override suspend fun getBusSchedule(routeInfo: BusRouteInfo): BusSchedule =
-        withContext(Dispatchers.IO) {
-            val dailyType = dailyTypeResolver.resolve(TransitType.BUS)
-            ApiClientUtils.callApiWithRetry(
-                primaryKey = serviceKey,
-                spareKey = spareKey,
-                realLastKey = realLastKey,
-                apiCall = { key -> publicGyeonggiRouteInfoFeignClient.getRouteInfo(key, routeInfo.routeId) },
-                isLimitExceeded = { response -> ApiClientUtils.isGyeonggiApiLimitExceeded(response) },
-                processResult = { response ->
-                    response.msgBody?.busRouteInfoItem?.toBusSchedule(dailyType, routeInfo.getTargetStation())
-                        ?: throw TransitException.of(
-                            TransitError.NOT_FOUND_BUS_SCHEDULE,
-                            "경기도 버스 노선 '${routeInfo.route.name}' 정류소" +
-                                " '${routeInfo.getTargetStation().stationName}'의 시간표 정보를 찾을 수 없습니다."
-                        )
-                },
-                errorMessage = "경기도 버스 노선 도착 정보를 가져오는데 실패했습니다."
-            )
-        }
+    override suspend fun getBusSchedule(routeInfo: BusRouteInfo): BusSchedule {
+        val dailyType = dailyTypeResolver.resolve(TransitType.BUS)
+        return ApiClientUtils.callApiWithRetry(
+            primaryKey = serviceKey,
+            spareKey = spareKey,
+            realLastKey = realLastKey,
+            apiCall = { key -> publicGyeonggiRouteInfoFeignClient.getRouteInfo(key, routeInfo.routeId) },
+            isLimitExceeded = { response -> ApiClientUtils.isGyeonggiApiLimitExceeded(response) },
+            processResult = { response ->
+                response.msgBody?.busRouteInfoItem?.toBusSchedule(dailyType, routeInfo.getTargetStation())
+                    ?: throw TransitException.of(
+                        TransitError.NOT_FOUND_BUS_SCHEDULE,
+                        "경기도 버스 노선 '${routeInfo.route.name}' 정류소" +
+                            " '${routeInfo.getTargetStation().stationName}'의 시간표 정보를 찾을 수 없습니다."
+                    )
+            },
+            errorMessage = "경기도 버스 노선 도착 정보를 가져오는데 실패했습니다."
+        )
+    }
 
     override suspend fun getBusRouteInfo(route: BusRoute): BusRouteOperationInfo =
-        withContext(Dispatchers.IO) {
-            ApiClientUtils.callApiWithRetry(
-                primaryKey = serviceKey,
-                spareKey = spareKey,
-                realLastKey = realLastKey,
-                apiCall = { key -> publicGyeonggiRouteInfoFeignClient.getRouteInfo(key, route.id.value) },
-                isLimitExceeded = { response -> ApiClientUtils.isGyeonggiApiLimitExceeded(response) },
-                processResult = { response ->
-                    response.msgBody?.busRouteInfoItem?.toBusRouteOperationInfo()
-                        ?: throw TransitException.of(
-                            TransitError.NOT_FOUND_BUS_OPERATION_INFO,
-                            "경기도 $route 노선 정보을 가져올 수 없습니다."
-                        )
-                },
-                errorMessage = "경기도 노선 운행 정보를 가져오는데 실패했습니다."
-            )
-        }
+        ApiClientUtils.callApiWithRetry(
+            primaryKey = serviceKey,
+            spareKey = spareKey,
+            realLastKey = realLastKey,
+            apiCall = { key -> publicGyeonggiRouteInfoFeignClient.getRouteInfo(key, route.id.value) },
+            isLimitExceeded = { response -> ApiClientUtils.isGyeonggiApiLimitExceeded(response) },
+            processResult = { response ->
+                response.msgBody?.busRouteInfoItem?.toBusRouteOperationInfo()
+                    ?: throw TransitException.of(
+                        TransitError.NOT_FOUND_BUS_OPERATION_INFO,
+                        "경기도 $route 노선 정보을 가져올 수 없습니다."
+                    )
+            },
+            errorMessage = "경기도 노선 운행 정보를 가져오는데 실패했습니다."
+        )
 
     @Cacheable(
         cacheNames = ["api:gyeonggi:busRouteStationList"],
@@ -107,59 +100,55 @@ class PublicGyeonggiRouteInfoClient(
         cacheManager = "apiCacheManager"
     )
     override suspend fun getStationList(route: BusRoute): BusRouteStationList =
-        withContext(Dispatchers.IO) {
-            ApiClientUtils.callApiWithRetry(
-                primaryKey = serviceKey,
-                spareKey = spareKey,
-                realLastKey = realLastKey,
-                apiCall = { key -> publicGyeonggiRouteInfoFeignClient.getRouteStationList(key, route.id.value) },
-                isLimitExceeded = { response -> ApiClientUtils.isGyeonggiApiLimitExceeded(response) },
-                processResult = { resp ->
-                    resp.msgBody?.busRouteStationList
-                        ?.takeIf { it.isNotEmpty() }
-                        ?.let { routeStations ->
-                            val busRouteStations =
-                                routeStations.map { it.toBusRouteStation(route) }
-                                    .filter(::isValidStation)
-                            BusRouteStationList(
-                                busRouteStations,
-                                routeStations.first().turnSeq
-                            )
-                        }
-                        ?: throw TransitException.of(
-                            TransitError.BUS_ROUTE_STATION_LIST_FETCH_FAILED,
-                            "경기도 버스 노선 '${route.name}-${route.id.value}' 경유 정류소를 찾을 수 없습니다."
+        ApiClientUtils.callApiWithRetry(
+            primaryKey = serviceKey,
+            spareKey = spareKey,
+            realLastKey = realLastKey,
+            apiCall = { key -> publicGyeonggiRouteInfoFeignClient.getRouteStationList(key, route.id.value) },
+            isLimitExceeded = { response -> ApiClientUtils.isGyeonggiApiLimitExceeded(response) },
+            processResult = { resp ->
+                resp.msgBody?.busRouteStationList
+                    ?.takeIf { it.isNotEmpty() }
+                    ?.let { routeStations ->
+                        val busRouteStations =
+                            routeStations.map { it.toBusRouteStation(route) }
+                                .filter(::isValidStation)
+                        BusRouteStationList(
+                            busRouteStations,
+                            routeStations.first().turnSeq
                         )
-                },
-                errorMessage = "경기도 버스 노선 경유 정류소를 가져오는데 실패했습니다."
-            )
-        }
+                    }
+                    ?: throw TransitException.of(
+                        TransitError.BUS_ROUTE_STATION_LIST_FETCH_FAILED,
+                        "경기도 버스 노선 '${route.name}-${route.id.value}' 경유 정류소를 찾을 수 없습니다."
+                    )
+            },
+            errorMessage = "경기도 버스 노선 경유 정류소를 가져오는데 실패했습니다."
+        )
 
     override suspend fun getBusRealTimeInfo(routeInfo: BusRouteInfo): BusRealTimeArrival =
-        withContext(Dispatchers.IO) {
-            ApiClientUtils.callApiWithRetry(
-                primaryKey = serviceKey,
-                spareKey = spareKey,
-                realLastKey = realLastKey,
-                apiCall = { key ->
-                    publicGyeonggiBusRealTimeInfoFeignClient.getRealTimeInfo(
-                        key,
-                        routeInfo.getTargetStation().stationId,
-                        routeInfo.routeId,
-                        routeInfo.getTargetStation().order.toString()
+        ApiClientUtils.callApiWithRetry(
+            primaryKey = serviceKey,
+            spareKey = spareKey,
+            realLastKey = realLastKey,
+            apiCall = { key ->
+                publicGyeonggiBusRealTimeInfoFeignClient.getRealTimeInfo(
+                    key,
+                    routeInfo.getTargetStation().stationId,
+                    routeInfo.routeId,
+                    routeInfo.getTargetStation().order.toString()
+                )
+            },
+            isLimitExceeded = { response -> ApiClientUtils.isGyeonggiApiLimitExceeded(response) },
+            processResult = { response ->
+                response.msgBody?.busArrivalItem?.toRealTimeArrival()
+                    ?: throw TransitException.of(
+                        TransitError.NOT_FOUND_BUS_REAL_TIME,
+                        "경기도 버스 도착 정보를 가져올 수 없습니다."
                     )
-                },
-                isLimitExceeded = { response -> ApiClientUtils.isGyeonggiApiLimitExceeded(response) },
-                processResult = { response ->
-                    response.msgBody?.busArrivalItem?.toRealTimeArrival()
-                        ?: throw TransitException.of(
-                            TransitError.NOT_FOUND_BUS_REAL_TIME,
-                            "경기도 버스 도착 정보를 가져올 수 없습니다."
-                        )
-                },
-                errorMessage =
-                    "경기도 버스(${routeInfo.route.id})의 " +
-                        "정류장(${routeInfo.getTargetStation().stationId}) 도착 정보를 가져오는데 실패했습니다."
-            )
-        }
+            },
+            errorMessage =
+                "경기도 버스(${routeInfo.route.id})의 " +
+                    "정류장(${routeInfo.getTargetStation().stationId}) 도착 정보를 가져오는데 실패했습니다."
+        )
 }

--- a/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/public/gyeonggi/response/GyeonggiBusRouteInfoResponse.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/public/gyeonggi/response/GyeonggiBusRouteInfoResponse.kt
@@ -12,6 +12,8 @@ import com.deepromeet.atcha.transit.domain.bus.BusServiceHours
 import com.deepromeet.atcha.transit.domain.bus.BusTimeTable
 import com.deepromeet.atcha.transit.domain.bus.BusTravelTimeCalculator
 import com.deepromeet.atcha.transit.domain.region.ServiceRegion
+import com.deepromeet.atcha.transit.exception.TransitError
+import com.deepromeet.atcha.transit.exception.TransitException
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -159,7 +161,9 @@ data class BusRouteInfoItem(
                     TransitTimeParser
                         .parseTime(last, LocalDate.now(), TIME_FORMATTER)
                         .plusMinutes(travelTimeFromStart),
-                term = termMap[dailyType] ?: 0
+                term =
+                    termMap[dailyType]
+                        ?: throw TransitException.of(TransitError.BUS_TERM_REQUIRED)
             )
         }
 

--- a/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/public/incheon/PublicIncheonBusPositionClient.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/public/incheon/PublicIncheonBusPositionClient.kt
@@ -4,8 +4,6 @@ import com.deepromeet.atcha.transit.application.bus.BusPositionFetcher
 import com.deepromeet.atcha.transit.domain.bus.BusPosition
 import com.deepromeet.atcha.transit.domain.bus.BusRouteId
 import com.deepromeet.atcha.transit.infrastructure.client.public.common.utils.ApiClientUtils
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
@@ -20,23 +18,21 @@ class PublicIncheonBusPositionClient(
     private val realLastKey: String
 ) : BusPositionFetcher {
     override suspend fun fetch(routeId: BusRouteId): List<BusPosition> =
-        withContext(Dispatchers.IO) {
-            ApiClientUtils.callApiWithRetry(
-                primaryKey = serviceKey,
-                spareKey = spareKey,
-                realLastKey = realLastKey,
-                apiCall = { key ->
-                    publicIncheonBusPositionFeignClient.getBusRouteLocation(
-                        serviceKey = key,
-                        routeId = routeId.value
-                    )
-                },
-                isLimitExceeded = { response -> ApiClientUtils.isServiceResultApiLimitExceeded(response) },
-                processResult = { response ->
-                    response.msgBody.itemList?.map { it.toBusPosition() }
-                        ?: emptyList()
-                },
-                errorMessage = "인천시 버스 위치 정보를 가져오는데 실패했습니다."
-            )
-        }
+        ApiClientUtils.callApiWithRetry(
+            primaryKey = serviceKey,
+            spareKey = spareKey,
+            realLastKey = realLastKey,
+            apiCall = { key ->
+                publicIncheonBusPositionFeignClient.getBusRouteLocation(
+                    serviceKey = key,
+                    routeId = routeId.value
+                )
+            },
+            isLimitExceeded = { response -> ApiClientUtils.isServiceResultApiLimitExceeded(response) },
+            processResult = { response ->
+                response.msgBody.itemList?.map { it.toBusPosition() }
+                    ?: emptyList()
+            },
+            errorMessage = "인천시 버스 위치 정보를 가져오는데 실패했습니다."
+        )
 }

--- a/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/public/incheon/PublicIncheonRouteInfoClient.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/public/incheon/PublicIncheonRouteInfoClient.kt
@@ -12,8 +12,6 @@ import com.deepromeet.atcha.transit.domain.bus.BusSchedule
 import com.deepromeet.atcha.transit.exception.TransitError
 import com.deepromeet.atcha.transit.exception.TransitException
 import com.deepromeet.atcha.transit.infrastructure.client.public.common.utils.ApiClientUtils
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Component
@@ -37,66 +35,60 @@ class PublicIncheonRouteInfoClient(
         cacheManager = "apiCacheManager"
     )
     override suspend fun getBusRoute(routeName: String): List<BusRoute> =
-        withContext(Dispatchers.IO) {
-            ApiClientUtils.callApiWithRetry(
-                primaryKey = serviceKey,
-                spareKey = spareKey,
-                realLastKey = realLastKey,
-                apiCall = { key -> incheonBusRouteInfoFeignClient.getBusRouteByName(key, routeName) },
-                isLimitExceeded = { response -> ApiClientUtils.isServiceResultApiLimitExceeded(response) },
-                processResult = { response ->
-                    response.msgBody.itemList
-                        ?.filter { it.routeNumber == routeName }
-                        ?.map { it.toBusRoute() }
-                        ?.takeIf { it.isNotEmpty() }
-                        ?: throw TransitException.of(
-                            TransitError.NOT_FOUND_BUS_ROUTE,
-                            "인천시 버스 노선 '$routeName'의 정보를 찾을 수 없습니다."
-                        )
-                },
-                errorMessage = "인천시 버스 노선 정보를 가져오는데 실패했습니다."
-            )
-        }
+        ApiClientUtils.callApiWithRetry(
+            primaryKey = serviceKey,
+            spareKey = spareKey,
+            realLastKey = realLastKey,
+            apiCall = { key -> incheonBusRouteInfoFeignClient.getBusRouteByName(key, routeName) },
+            isLimitExceeded = { response -> ApiClientUtils.isServiceResultApiLimitExceeded(response) },
+            processResult = { response ->
+                response.msgBody.itemList
+                    ?.filter { it.routeNumber == routeName }
+                    ?.map { it.toBusRoute() }
+                    ?.takeIf { it.isNotEmpty() }
+                    ?: throw TransitException.of(
+                        TransitError.NOT_FOUND_BUS_ROUTE,
+                        "인천시 버스 노선 '$routeName'의 정보를 찾을 수 없습니다."
+                    )
+            },
+            errorMessage = "인천시 버스 노선 정보를 가져오는데 실패했습니다."
+        )
 
     override suspend fun getBusSchedule(routeInfo: BusRouteInfo): BusSchedule =
-        withContext(Dispatchers.IO) {
-            ApiClientUtils.callApiWithRetry(
-                primaryKey = serviceKey,
-                spareKey = spareKey,
-                realLastKey = realLastKey,
-                apiCall = { key ->
-                    incheonBusRouteInfoFeignClient.getBusRouteInfoById(key, routeInfo.routeId)
-                },
-                isLimitExceeded = { response -> ApiClientUtils.isServiceResultApiLimitExceeded(response) },
-                processResult = { response ->
-                    response.msgBody.itemList?.get(0)?.toBusSchedule(routeInfo.getTargetStation())
-                        ?: throw TransitException.of(
-                            TransitError.NOT_FOUND_BUS_ROUTE,
-                            "인천시 버스 노선-${routeInfo.route.name}-${routeInfo.route.id.value}의 정보를 찾을 수 없습니다."
-                        )
-                },
-                errorMessage = "인천시 버스 정류소-${routeInfo.getTargetStation().stationId} 정보를 가져오는데 실패했습니다."
-            )
-        }
+        ApiClientUtils.callApiWithRetry(
+            primaryKey = serviceKey,
+            spareKey = spareKey,
+            realLastKey = realLastKey,
+            apiCall = { key ->
+                incheonBusRouteInfoFeignClient.getBusRouteInfoById(key, routeInfo.routeId)
+            },
+            isLimitExceeded = { response -> ApiClientUtils.isServiceResultApiLimitExceeded(response) },
+            processResult = { response ->
+                response.msgBody.itemList?.get(0)?.toBusSchedule(routeInfo.getTargetStation())
+                    ?: throw TransitException.of(
+                        TransitError.NOT_FOUND_BUS_ROUTE,
+                        "인천시 버스 노선-${routeInfo.route.name}-${routeInfo.route.id.value}의 정보를 찾을 수 없습니다."
+                    )
+            },
+            errorMessage = "인천시 버스 정류소-${routeInfo.getTargetStation().stationId} 정보를 가져오는데 실패했습니다."
+        )
 
     override suspend fun getBusRouteInfo(route: BusRoute): BusRouteOperationInfo =
-        withContext(Dispatchers.IO) {
-            ApiClientUtils.callApiWithRetry(
-                primaryKey = serviceKey,
-                spareKey = spareKey,
-                realLastKey = realLastKey,
-                apiCall = { key -> incheonBusRouteInfoFeignClient.getBusRouteInfoById(key, route.id.value) },
-                isLimitExceeded = { response -> ApiClientUtils.isServiceResultApiLimitExceeded(response) },
-                processResult = { response ->
-                    response.msgBody.itemList?.get(0)?.toBusRouteOperationInfo()
-                        ?: throw TransitException.of(
-                            TransitError.NOT_FOUND_BUS_OPERATION_INFO,
-                            "인천시 버스 노선-${route.name}-${route.id.value}의 운영 정보를 찾을 수 없습니다."
-                        )
-                },
-                errorMessage = "인천시 버스 노선-${route.name}-${route.id.value}의 운영 정보를 가져오는데 실패했습니다."
-            )
-        }
+        ApiClientUtils.callApiWithRetry(
+            primaryKey = serviceKey,
+            spareKey = spareKey,
+            realLastKey = realLastKey,
+            apiCall = { key -> incheonBusRouteInfoFeignClient.getBusRouteInfoById(key, route.id.value) },
+            isLimitExceeded = { response -> ApiClientUtils.isServiceResultApiLimitExceeded(response) },
+            processResult = { response ->
+                response.msgBody.itemList?.get(0)?.toBusRouteOperationInfo()
+                    ?: throw TransitException.of(
+                        TransitError.NOT_FOUND_BUS_OPERATION_INFO,
+                        "인천시 버스 노선-${route.name}-${route.id.value}의 운영 정보를 찾을 수 없습니다."
+                    )
+            },
+            errorMessage = "인천시 버스 노선-${route.name}-${route.id.value}의 운영 정보를 가져오는데 실패했습니다."
+        )
 
     @Cacheable(
         cacheNames = ["api:incheon:busRouteStationList"],
@@ -105,66 +97,62 @@ class PublicIncheonRouteInfoClient(
         cacheManager = "apiCacheManager"
     )
     override suspend fun getStationList(route: BusRoute): BusRouteStationList =
-        withContext(Dispatchers.IO) {
-            ApiClientUtils.callApiWithRetry(
-                primaryKey = serviceKey,
-                spareKey = spareKey,
-                realLastKey = realLastKey,
-                apiCall = { key ->
-                    incheonBusRouteInfoFeignClient.getBusRouteSectionList(key, route.id.value)
-                },
-                isLimitExceeded = { response -> ApiClientUtils.isServiceResultApiLimitExceeded(response) },
-                processResult = { response ->
-                    val turnPoint = response.msgBody.itemList?.first { it.directionCode == 1 }
+        ApiClientUtils.callApiWithRetry(
+            primaryKey = serviceKey,
+            spareKey = spareKey,
+            realLastKey = realLastKey,
+            apiCall = { key ->
+                incheonBusRouteInfoFeignClient.getBusRouteSectionList(key, route.id.value)
+            },
+            isLimitExceeded = { response -> ApiClientUtils.isServiceResultApiLimitExceeded(response) },
+            processResult = { response ->
+                val turnPoint = response.msgBody.itemList?.first { it.directionCode == 1 }
 
-                    val routeStations =
-                        response.msgBody.itemList
-                            ?.filter { station ->
-                                NON_STOP_STATION_NAME.none { keyword -> station.stationName.contains(keyword) }
-                            }
-                            ?.map {
-                                it.toBusRouteStation(
-                                    route,
-                                    turnPoint?.stationSequence,
-                                    coordinateTransformer.transformToWGS84(it.positionX, it.positionY)
-                                )
-                            }
-                            ?: throw TransitException.of(
-                                TransitError.BUS_ROUTE_STATION_LIST_FETCH_FAILED,
-                                "인천시 버스 노선-${route.name}-${route.id.value}의 경유 정류소 정보를 찾을 수 없습니다."
+                val routeStations =
+                    response.msgBody.itemList
+                        ?.filter { station ->
+                            NON_STOP_STATION_NAME.none { keyword -> station.stationName.contains(keyword) }
+                        }
+                        ?.map {
+                            it.toBusRouteStation(
+                                route,
+                                turnPoint?.stationSequence,
+                                coordinateTransformer.transformToWGS84(it.positionX, it.positionY)
                             )
+                        }
+                        ?: throw TransitException.of(
+                            TransitError.BUS_ROUTE_STATION_LIST_FETCH_FAILED,
+                            "인천시 버스 노선-${route.name}-${route.id.value}의 경유 정류소 정보를 찾을 수 없습니다."
+                        )
 
-                    BusRouteStationList(
-                        routeStations,
-                        turnPoint?.stationSequence
-                    )
-                },
-                errorMessage = "인천시 버스 노선 스케줄 정보를 가져오는데 실패했습니다."
-            )
-        }
+                BusRouteStationList(
+                    routeStations,
+                    turnPoint?.stationSequence
+                )
+            },
+            errorMessage = "인천시 버스 노선 스케줄 정보를 가져오는데 실패했습니다."
+        )
 
     override suspend fun getBusRealTimeInfo(routeInfo: BusRouteInfo): BusRealTimeArrival =
-        withContext(Dispatchers.IO) {
-            ApiClientUtils.callApiWithRetry(
-                primaryKey = serviceKey,
-                spareKey = spareKey,
-                realLastKey = realLastKey,
-                apiCall = { key ->
-                    publicIncheonBusArrivalFeignClient.getBusArrivalList(
-                        key,
-                        routeInfo.routeId,
-                        routeInfo.getTargetStation().stationId
-                    )
-                },
-                isLimitExceeded = { response -> ApiClientUtils.isServiceResultApiLimitExceeded(response) },
-                processResult = { response ->
-                    response.msgBody.itemList?.getOrNull(0)
-                        ?.toBusRealTimeArrival()
-                        ?: BusRealTimeArrival(emptyList())
-                },
-                errorMessage =
-                    "인천시 버스(${routeInfo.route.id})의 " +
-                        "정류장(${routeInfo.getTargetStation().stationId}) 도착 정보를 가져오는데 실패했습니다."
-            )
-        }
+        ApiClientUtils.callApiWithRetry(
+            primaryKey = serviceKey,
+            spareKey = spareKey,
+            realLastKey = realLastKey,
+            apiCall = { key ->
+                publicIncheonBusArrivalFeignClient.getBusArrivalList(
+                    key,
+                    routeInfo.routeId,
+                    routeInfo.getTargetStation().stationId
+                )
+            },
+            isLimitExceeded = { response -> ApiClientUtils.isServiceResultApiLimitExceeded(response) },
+            processResult = { response ->
+                response.msgBody.itemList?.getOrNull(0)
+                    ?.toBusRealTimeArrival()
+                    ?: BusRealTimeArrival(emptyList())
+            },
+            errorMessage =
+                "인천시 버스(${routeInfo.route.id})의 " +
+                    "정류장(${routeInfo.getTargetStation().stationId}) 도착 정보를 가져오는데 실패했습니다."
+        )
 }

--- a/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/public/seoul/PublicSeoulBusPositionClient.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/client/public/seoul/PublicSeoulBusPositionClient.kt
@@ -5,8 +5,6 @@ import com.deepromeet.atcha.transit.domain.bus.BusPosition
 import com.deepromeet.atcha.transit.domain.bus.BusRouteId
 import com.deepromeet.atcha.transit.infrastructure.client.public.common.utils.ApiClientUtils
 import com.deepromeet.atcha.transit.infrastructure.client.public.common.utils.ApiClientUtils.isServiceResultApiLimitExceeded
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
@@ -21,19 +19,17 @@ class PublicSeoulBusPositionClient(
     private val realLastKey: String
 ) : BusPositionFetcher {
     override suspend fun fetch(routeId: BusRouteId): List<BusPosition> =
-        withContext(Dispatchers.IO) {
-            ApiClientUtils.callApiWithRetry(
-                primaryKey = serviceKey,
-                spareKey = spareKey,
-                realLastKey = realLastKey,
-                apiCall = { key -> publicSeoulBusPositionClient.getBusPosByRtid(key, routeId.value) },
-                isLimitExceeded = { response -> isServiceResultApiLimitExceeded(response) },
-                processResult = { response ->
-                    response.msgBody.itemList?.map { busPositionResponse ->
-                        busPositionResponse.toBusPosition()
-                    } ?: emptyList()
-                },
-                errorMessage = "서울 버스 위치 정보를 가져오는데 실패했습니다."
-            )
-        }
+        ApiClientUtils.callApiWithRetry(
+            primaryKey = serviceKey,
+            spareKey = spareKey,
+            realLastKey = realLastKey,
+            apiCall = { key -> publicSeoulBusPositionClient.getBusPosByRtid(key, routeId.value) },
+            isLimitExceeded = { response -> isServiceResultApiLimitExceeded(response) },
+            processResult = { response ->
+                response.msgBody.itemList?.map { busPositionResponse ->
+                    busPositionResponse.toBusPosition()
+                } ?: emptyList()
+            },
+            errorMessage = "서울 버스 위치 정보를 가져오는데 실패했습니다."
+        )
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,7 +57,7 @@ open-api:
   limits:
     default: 100
     per-api:
-      subway-schedule: 20
+      subway-schedule: 10
       gyeonggi-route: 30
       incheon-route: 3
       incheon-arrival: 10

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,7 +57,7 @@ open-api:
   limits:
     default: 100
     per-api:
-      subway-schedule: 30
+      subway-schedule: 20
       gyeonggi-route: 30
       incheon-route: 3
       incheon-arrival: 10


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #350 

## 📝작업 내용

- 20:00 ~ 03:00 사이의 출발시간인 막차 경로만 나오도록 변경
- 첫번째 버스가 아닌 경우 전막차 기준으로 시간 세팅 하도록 변경

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  -
