### PR TITLE
[#364] 막차 탑승 시간 조회 및 지하철 공휴일 시간표

### DIFF
--- a/src/main/kotlin/com/deepromeet/atcha/route/api/RouteController.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/api/RouteController.kt
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
@@ -107,10 +108,14 @@ class RouteController(
 
     @GetMapping("/user-routes/bus-arrival")
     suspend fun getBusArrivalInUserRoute(
-        @CurrentUser id: Long
-    ): ApiResponse<RealTimeBusArrivalResponse> {
+        @CurrentUser id: Long,
+        @RequestParam routeName: String
+    ): ApiResponse<List<RealTimeBusArrivalResponse>> {
         return ApiResponse.success(
-            RealTimeBusArrivalResponse(routeService.getFirstBusArrival(UserId(id)))
+            routeService.getTargetBusArrivals(
+                UserId(id),
+                routeName
+            ).map { RealTimeBusArrivalResponse(it) }
         )
     }
 

--- a/src/main/kotlin/com/deepromeet/atcha/route/application/LastRouteLegCalculator.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/application/LastRouteLegCalculator.kt
@@ -10,7 +10,6 @@ import com.deepromeet.atcha.transit.application.subway.SubwayManager
 import com.deepromeet.atcha.transit.domain.TransitInfo
 import com.deepromeet.atcha.transit.domain.subway.SubwayLine
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -27,7 +26,7 @@ class LastRouteLegCalculator(
     suspend fun calcWithLastTime(legs: List<RouteLeg>): List<LastRouteLeg> {
         return coroutineScope {
             legs.map { leg ->
-                async(Dispatchers.Default) {
+                async {
                     when (leg.mode) {
                         RouteMode.SUBWAY -> calculateSubwayLeg(leg)
                         RouteMode.BUS -> calculateBusLeg(leg)

--- a/src/main/kotlin/com/deepromeet/atcha/route/application/LastRouteUpdater.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/application/LastRouteUpdater.kt
@@ -12,14 +12,14 @@ class LastRouteUpdater(
     /**
      * 실시간 정보로 첫 번째 버스의 출발 시간을 업데이트하고 캐시에 저장
      */
-    fun updateFirstBusTime(
+    fun updateDepartureTime(
         lastRoute: LastRoute,
-        firstBus: LastRouteLeg,
+        targetLeg: LastRouteLeg,
         newArrivalTime: LocalDateTime
     ) {
         val updatedLegs =
             lastRoute.legs.map { leg ->
-                if (leg == firstBus) {
+                if (leg == targetLeg) {
                     leg.copy(departureDateTime = newArrivalTime)
                 } else {
                     leg

--- a/src/main/kotlin/com/deepromeet/atcha/route/application/RouteArrivalCalculator.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/application/RouteArrivalCalculator.kt
@@ -11,19 +11,19 @@ class RouteArrivalCalculator(
     private val busManager: BusManager
 ) {
     suspend fun closestArrival(
-        busLeg: LastRouteLeg,
+        targetBus: LastRouteLeg,
         scheduled: LocalDateTime
-    ): BusArrival? {
-        val busInfo = busLeg.requireBusInfo()
+    ): List<BusArrival>? {
+        val busInfo = targetBus.requireBusInfo()
         val arrivals =
             busManager.getRealTimeArrival(
-                busLeg.resolveRouteName(),
-                busLeg.toBusStationMeta(),
-                busLeg.passStops!!
+                targetBus.resolveRouteName(),
+                targetBus.toBusStationMeta(),
+                targetBus.passStops!!
             )
         val positions = busManager.getBusPositions(busInfo.busRouteInfo.route)
         val approachingBuses = positions.getApproachingBuses(busInfo.busStation)
 
-        return arrivals.getClosestArrivalWithPositions(busInfo.timeTable, scheduled, approachingBuses)
+        return arrivals.getClosestArrivalsWithPositions(busInfo.timeTable, scheduled, approachingBuses)
     }
 }

--- a/src/main/kotlin/com/deepromeet/atcha/route/application/RouteArrivalSelectionPolicy.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/application/RouteArrivalSelectionPolicy.kt
@@ -5,10 +5,13 @@ import com.deepromeet.atcha.transit.domain.bus.BusTimeTable
 import org.springframework.stereotype.Component
 import java.time.Duration
 import java.time.LocalDateTime
+import kotlin.takeIf
+
+private const val MAX_EARLY_ARRIVAL_MINUTES = 60
 
 interface RouteArrivalSelectionPolicy {
     fun select(
-        scheduled: LocalDateTime,
+        scheduledTime: LocalDateTime,
         closestBusInfo: BusArrival?,
         timeTable: BusTimeTable
     ): BusArrival?
@@ -17,16 +20,23 @@ interface RouteArrivalSelectionPolicy {
 @Component
 class HalfHeadwayPolicyRoute : RouteArrivalSelectionPolicy {
     override fun select(
-        scheduled: LocalDateTime,
+        scheduledTime: LocalDateTime,
         closestBusInfo: BusArrival?,
         timeTable: BusTimeTable
     ): BusArrival? {
         if (closestBusInfo?.expectedArrivalTime == null) return null
 
-        val closest = closestBusInfo.expectedArrivalTime!!
-        val diffMin = Duration.between(scheduled, closest).toMinutes().toDouble()
-        val threshold = timeTable.term / 2.0
+        val closestTime = closestBusInfo.expectedArrivalTime!!
+        val diffMin = Duration.between(scheduledTime, closestTime).toMinutes().toDouble()
 
-        return if (diffMin > threshold) null else closestBusInfo
+        return closestBusInfo.takeIf { isValidRefreshedTime(diffMin, timeTable) }
+    }
+
+    private fun isValidRefreshedTime(
+        diffMin: Double,
+        timeTable: BusTimeTable
+    ): Boolean {
+        val threshold = timeTable.term / 2.0
+        return diffMin >= -MAX_EARLY_ARRIVAL_MINUTES && diffMin < threshold
     }
 }

--- a/src/main/kotlin/com/deepromeet/atcha/route/domain/LastRoute.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/domain/LastRoute.kt
@@ -41,6 +41,13 @@ data class LastRoute(
         )
     }
 
+    fun findBus(routeName: String): LastRouteLeg {
+        return legs.firstOrNull { it.route.equals(routeName) } ?: throw RouteException.of(
+            RouteError.INVALID_LAST_ROUTE,
+            "$id 경로에서 ${routeName}에 해당하는 버스를 찾을 수 없습니다."
+        )
+    }
+
     fun calcWalkingTimeToFirstTransit(): Long =
         legs.takeWhile { !it.isTransit() }
             .sumOf { it.sectionTime }

--- a/src/main/kotlin/com/deepromeet/atcha/route/domain/LastRouteLeg.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/domain/LastRouteLeg.kt
@@ -48,6 +48,8 @@ data class LastRouteLeg(
 
     fun isBus(): Boolean = mode == RouteMode.BUS
 
+    fun isSubway(): Boolean = mode == RouteMode.SUBWAY
+
     fun resolveRouteName(): String {
         return route!!.split(":")[1]
     }

--- a/src/main/kotlin/com/deepromeet/atcha/route/domain/UserRoute.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/domain/UserRoute.kt
@@ -25,6 +25,10 @@ data class UserRoute(
         userId = userId
     )
 
+    fun isUpdated(): Boolean {
+        return baseDepartureTime != updatedDepartureTime
+    }
+
     fun updateDepartureTime(newDepartureTime: LocalDateTime) =
         this.copy(
             updatedDepartureTime = newDepartureTime,

--- a/src/main/kotlin/com/deepromeet/atcha/route/infrastructure/scheduler/UserRouteRefreshScheduler.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/infrastructure/scheduler/UserRouteRefreshScheduler.kt
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component
 class UserRouteRefreshScheduler(
     private val userRouteRefreshService: UserRouteRefreshService
 ) {
-    @Scheduled(cron = "0 0/3 * * * ?")
+    @Scheduled(cron = "0 0/1 * * * ?")
     @SchedulerLock(name = "refresh_departure_time", lockAtMostFor = "PT2S", lockAtLeastFor = "PT2S")
     fun processRefresh() =
         runBlocking {

--- a/src/main/kotlin/com/deepromeet/atcha/route/infrastructure/scheduler/UserRouteRefreshScheduler.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/infrastructure/scheduler/UserRouteRefreshScheduler.kt
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Component
 class UserRouteRefreshScheduler(
     private val userRouteRefreshService: UserRouteRefreshService
 ) {
-    @Scheduled(cron = "0 0/1 * * * ?")
-    @SchedulerLock(name = "refresh_departure_time", lockAtMostFor = "PT2S", lockAtLeastFor = "PT2S")
+    @Scheduled(cron = "0 0/3 * * * ?")
+    @SchedulerLock(name = "refresh_departure_time", lockAtMostFor = "PT5S", lockAtLeastFor = "PT3S")
     fun processRefresh() =
         runBlocking {
             userRouteRefreshService.refreshAllAndPublishEvents()

--- a/src/main/kotlin/com/deepromeet/atcha/transit/application/DailyTypeResolver.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/application/DailyTypeResolver.kt
@@ -13,7 +13,7 @@ class DailyTypeResolver(
 ) {
     suspend fun resolve(
         transitType: TransitType,
-        date: LocalDate = LocalDate.of(2025, 8, 15)
+        date: LocalDate = LocalDate.now()
     ): DailyType {
         return when (transitType) {
             TransitType.SUBWAY, TransitType.BUS -> resolveDailyType(date)

--- a/src/main/kotlin/com/deepromeet/atcha/transit/application/DailyTypeResolver.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/application/DailyTypeResolver.kt
@@ -13,7 +13,7 @@ class DailyTypeResolver(
 ) {
     suspend fun resolve(
         transitType: TransitType,
-        date: LocalDate = LocalDate.now()
+        date: LocalDate = LocalDate.of(2025, 8, 15)
     ): DailyType {
         return when (transitType) {
             TransitType.SUBWAY, TransitType.BUS -> resolveDailyType(date)
@@ -21,8 +21,9 @@ class DailyTypeResolver(
     }
 
     private suspend fun resolveDailyType(date: LocalDate): DailyType {
+        val isHoliday = isHoliday(date)
         return when {
-            isHoliday(date) -> DailyType.HOLIDAY
+            isHoliday -> DailyType.HOLIDAY
             date.dayOfWeek == DayOfWeek.SATURDAY -> DailyType.SATURDAY
             date.dayOfWeek == DayOfWeek.SUNDAY -> DailyType.SUNDAY
             else -> DailyType.WEEKDAY

--- a/src/main/kotlin/com/deepromeet/atcha/transit/domain/bus/BusArrival.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/domain/bus/BusArrival.kt
@@ -35,7 +35,7 @@ data class BusArrival(
 
             return BusArrival(
                 vehicleId = "scheduled",
-                busStatus = BusStatus.OPERATING,
+                busStatus = BusStatus.WAITING,
                 remainingTime = remainingSeconds,
                 remainingStations = null,
                 isLast = false,

--- a/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/cache/HolidayRedisCache.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/cache/HolidayRedisCache.kt
@@ -16,7 +16,8 @@ class HolidayRedisCache(
 
     override fun getHolidays(year: Int): List<LocalDate>? {
         val key = getKey(year)
-        return holidayRedisTemplate.opsForValue().get(key)
+        val get = holidayRedisTemplate.opsForValue().get(key)
+        return get
     }
 
     private fun getKey(year: Int): String {

--- a/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/cache/config/HolidayRedisConfig.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/cache/config/HolidayRedisConfig.kt
@@ -1,6 +1,7 @@
 package com.deepromeet.atcha.transit.infrastructure.cache.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -18,6 +19,7 @@ class HolidayRedisConfig {
         val objectMapper =
             ObjectMapper()
                 .registerModule(JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
         val jsonSerializer = GenericJackson2JsonRedisSerializer(objectMapper)
 
         // RedisTemplate 설정


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #364 

## 📝작업 내용

-

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  -


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 사용자 경로 버스 도착 조회에 노선명 필터 추가 및 다건 결과 제공
  - 가장 가까운 실시간 도착 최대 2건 제시, 예약된 차량은 ‘대기(WAITING)’ 상태로 표시

- Bug Fixes
  - 지하철 대기 시간이 20분 초과하면 검증 오류로 차단
  - 여정 검증 규칙 보완: 중간 버스 금지, 버스 최대 2구간 허용

- Chores
  - 갱신 대상/임계값 조정(2분 미만 제외) 및 계산 후보를 접근 중인 버스로 제한
  - 스케줄러 락 지속시간 조정(최대/최소 변경)
  - 공휴일 캐시 일자 ISO 형식 직렬화 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->