### PR TITLE
[#376] 지하철 급행 및 막차 구분 추가

### DIFF
--- a/.github/workflows/run-detekt.yml.disabled
+++ b/.github/workflows/run-detekt.yml.disabled
@@ -1,8 +1,7 @@
 name: run detekt
 on:
   pull_request:
-    branches:
-      - dev
+    branches: [ dev ]
 jobs:
   detekt:
     runs-on: ubuntu-latest

--- a/.github/workflows/staging-deploy.yml.disabled
+++ b/.github/workflows/staging-deploy.yml.disabled
@@ -3,7 +3,7 @@ name: STAGING CD
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ ]
+    branches: [ dev ]
 
 jobs:
   build:

--- a/src/main/kotlin/com/deepromeet/atcha/route/api/response/LastRouteResponse.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/api/response/LastRouteResponse.kt
@@ -50,6 +50,8 @@ data class LastRouteLegResponse(
     val targetBusTerm: Int? = null,
     val subwayFinalStation: String? = null,
     val subwayDirection: String? = null,
+    val isExpressSubway: Boolean? = null,
+    val isLastSubway: Boolean? = null,
     val passStopList: List<RoutePassStopResponse>? = null,
     val step: List<RouteStep>? = null,
     val passShape: String? = null
@@ -77,6 +79,11 @@ data class LastRouteLegResponse(
         targetBusTerm = lastRouteLeg.busInfo?.timeTable?.term,
         subwayFinalStation = lastRouteLeg.subwayInfo?.resolveFinalStationName(),
         subwayDirection = lastRouteLeg.subwayInfo?.resolveDirectionName(),
+        isExpressSubway = lastRouteLeg.subwayInfo?.isExpress,
+        isLastSubway =
+            lastRouteLeg.subwayInfo?.lastSchedule?.departureTime?.toLocalDateTime()?.isEqual(
+                lastRouteLeg.departureDateTime
+            ),
         passStopList = lastRouteLeg.passStops?.stops?.map { RoutePassStopResponse(it) },
         step = lastRouteLeg.steps,
         passShape = lastRouteLeg.pathCoordinates

--- a/src/main/kotlin/com/deepromeet/atcha/route/application/LastRouteCalculatorV2.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/application/LastRouteCalculatorV2.kt
@@ -112,7 +112,13 @@ class LastRouteCalculatorV2(
 
                             leg.toLastTransitLeg(
                                 departureDateTime = cursor.truncatedTo(ChronoUnit.SECONDS),
-                                transitInfo = TransitInfo.SubwayInfo(subwayLine, timeTable, timeTable.schedules[0])
+                                transitInfo =
+                                    TransitInfo.SubwayInfo(
+                                        subwayLine,
+                                        timeTable,
+                                        timeTable.schedules[0],
+                                        leg.isExpress()
+                                    )
                             )
                         } catch (e: Exception) {
                             log.warn(e) { "지하철 정보 조회 실패, 기본값 사용: ${leg.route}, ${leg.start.name}, ${leg.end.name}" }

--- a/src/main/kotlin/com/deepromeet/atcha/route/application/LastRouteLegCalculator.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/route/application/LastRouteLegCalculator.kt
@@ -58,11 +58,11 @@ class LastRouteLegCalculator(
                 val nextStation = nextStationDeferred.await()
 
                 val timeTable = subwayManager.getTimeTable(startStation, nextStation, endStation, routes)
-                val lastSchedule = timeTable.getLastTime(endStation, routes, leg.isExpress())
+                val lastSchedule = timeTable.getLastTime(endStation, leg.isExpress())
 
                 leg.toLastTransitLeg(
                     departureDateTime = lastSchedule.departureTime.toLocalDateTime().truncatedTo(ChronoUnit.SECONDS),
-                    transitInfo = TransitInfo.SubwayInfo(subwayLine, timeTable, lastSchedule)
+                    transitInfo = TransitInfo.SubwayInfo(subwayLine, timeTable, lastSchedule, leg.isExpress())
                 )
             }
         } catch (e: Exception) {

--- a/src/main/kotlin/com/deepromeet/atcha/transit/application/subway/SubwayManager.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/application/subway/SubwayManager.kt
@@ -55,9 +55,12 @@ class SubwayManager(
         val dailyType = dailyTypeResolver.resolve(TransitType.SUBWAY)
         val direction = SubwayDirection.resolve(routes, startStation, nextStation, endStation)
 
-        return subwayTimeTableCache.get(startStation, dailyType, direction)
-            ?: subwayTimetableClient.getTimeTable(startStation, dailyType, direction).also { timeTable ->
-                subwayTimeTableCache.cache(startStation, dailyType, direction, timeTable)
-            }
+        val subwayTimeTable =
+            subwayTimeTableCache.get(startStation, dailyType, direction)
+                ?: subwayTimetableClient.getTimeTable(startStation, dailyType, direction).also { timeTable ->
+                    subwayTimeTableCache.cache(startStation, dailyType, direction, timeTable)
+                }
+
+        return subwayTimeTable.filterReachable(endStation, routes)
     }
 }

--- a/src/main/kotlin/com/deepromeet/atcha/transit/domain/TransitInfo.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/domain/TransitInfo.kt
@@ -12,11 +12,12 @@ sealed class TransitInfo {
     data class SubwayInfo(
         val subwayLine: SubwayLine,
         val timeTable: SubwayTimeTable,
-        val targetSchedule: SubwaySchedule
+        val lastSchedule: SubwaySchedule,
+        val isExpress: Boolean
     ) : TransitInfo() {
-        fun resolveFinalStationName(): String = targetSchedule.finalStation.name
+        fun resolveFinalStationName(): String = lastSchedule.finalStation.name
 
-        fun resolveDirectionName(): String = targetSchedule.subwayDirection.getName(subwayLine.isCircular)
+        fun resolveDirectionName(): String = lastSchedule.subwayDirection.getName(subwayLine.isCircular)
     }
 
     data class BusInfo(

--- a/src/main/kotlin/com/deepromeet/atcha/transit/domain/subway/SubwayTimeTable.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/domain/subway/SubwayTimeTable.kt
@@ -14,12 +14,10 @@ data class SubwayTimeTable(
 ) {
     fun getLastTime(
         destinationStation: SubwayStation,
-        routes: List<Route>,
         isExpress: Boolean
     ): SubwaySchedule =
         schedules
             .filter { it.isExpress == isExpress }
-            .filter { isReachable(startStation, destinationStation, it.finalStation, routes, subwayDirection) }
             .maxByOrNull { it.departureTime.toLocalDateTime() }
             ?: throw TransitException.of(
                 TransitError.NOT_FOUND_SUBWAY_LAST_TIME,
@@ -47,15 +45,17 @@ data class SubwayTimeTable(
             }
         }
 
-    private fun isReachable(
-        startStation: SubwayStation,
+    fun filterReachable(endStation: SubwayStation, routes: List<Route>): SubwayTimeTable {
+        return copy(schedules = schedules.filter { isReachable(endStation, it.finalStation, routes) })
+    }
+
+    fun isReachable(
         endStation: SubwayStation,
         finalStation: SubwayStation,
         routes: List<Route>,
-        direction: SubwayDirection
     ): Boolean {
         return routes.any { route ->
-            route.isReachable(startStation.name, endStation.name, finalStation.name, direction)
+            route.isReachable(startStation.name, endStation.name, finalStation.name, subwayDirection)
         }
     }
 }

--- a/src/main/kotlin/com/deepromeet/atcha/transit/domain/subway/SubwayTimeTable.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/domain/subway/SubwayTimeTable.kt
@@ -45,14 +45,17 @@ data class SubwayTimeTable(
             }
         }
 
-    fun filterReachable(endStation: SubwayStation, routes: List<Route>): SubwayTimeTable {
+    fun filterReachable(
+        endStation: SubwayStation,
+        routes: List<Route>
+    ): SubwayTimeTable {
         return copy(schedules = schedules.filter { isReachable(endStation, it.finalStation, routes) })
     }
 
     fun isReachable(
         endStation: SubwayStation,
         finalStation: SubwayStation,
-        routes: List<Route>,
+        routes: List<Route>
     ): Boolean {
         return routes.any { route ->
             route.isReachable(startStation.name, endStation.name, finalStation.name, subwayDirection)


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #376 

## 📝작업 내용

-

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  -


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 에러 응답에 Server-Sent Events(SSE) 지원 추가(요청 헤더에 따라 SSE 또는 일반 JSON 반환).
  - 경로 결과에 지하철 급행 여부와 막차 여부 정보가 표시됩니다.

- 개선
  - 에러 메시지 가독성 및 일관성 향상(특정 예외 상황 설명 강화).
  - 지하철 시간표 처리에서 도달 가능성 필터링을 분리해 선택 로직의 명확성 향상.

- 리팩터링
  - 급행 정보가 경로 계산 전반에 일관되게 반영되도록 내부 흐름 정리.

- 작업(Chores)
  - 정적 분석 워크플로의 PR 트리거 비활성화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->