### PR TITLE
feat: 지하철역 이름 매칭 로직 정규화

### DIFF
--- a/src/main/kotlin/com/deepromeet/atcha/transit/application/subway/SubwayManager.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/application/subway/SubwayManager.kt
@@ -48,7 +48,8 @@ class SubwayManager(
     ): SubwayStation {
         return subwayStationCache.get(subwayLine, stationName)
             ?: withContext(Dispatchers.IO) {
-                subwayStationRepository.findStationByNameAndRoute(subwayLine.lnCd, stationName)
+                val normalized = SubwayStation.normalize(stationName)
+                subwayStationRepository.findStationByNameAndRoute(subwayLine.lnCd, normalized)
                     ?: throw TransitException.of(
                         TransitError.NOT_FOUND_SUBWAY_STATION,
                         "DB에서 지하철 노선 '${subwayLine.mainName()}'의 역 '$stationName'을 찾을 수 없습니다."

--- a/src/main/kotlin/com/deepromeet/atcha/transit/application/subway/SubwayManager.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/application/subway/SubwayManager.kt
@@ -49,7 +49,11 @@ class SubwayManager(
         return subwayStationCache.get(subwayLine, stationName)
             ?: withContext(Dispatchers.IO) {
                 val normalized = SubwayStation.normalize(stationName)
-                subwayStationRepository.findStationByNameAndRoute(subwayLine.lnCd, normalized)
+                val routeCode = subwayLine.lnCd
+                (
+                    subwayStationRepository.findFirstByRouteCodeAndNormalizedName(routeCode, normalized)
+                        ?: subwayStationRepository.findFirstByRouteCodeAndNameLike(routeCode, "%($normalized)%")
+                )
                     ?: throw TransitException.of(
                         TransitError.NOT_FOUND_SUBWAY_STATION,
                         "DB에서 지하철 노선 '${subwayLine.mainName()}'의 역 '$stationName'을 찾을 수 없습니다."

--- a/src/main/kotlin/com/deepromeet/atcha/transit/domain/subway/SubwayStation.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/domain/subway/SubwayStation.kt
@@ -10,7 +10,8 @@ class SubwayStation(
     val stationCode: String,
     val name: String,
     val routeName: String,
-    val routeCode: String
+    val routeCode: String,
+    val normalizedName: String = normalize(name)
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -29,7 +30,16 @@ class SubwayStation(
         return javaClass.hashCode()
     }
 
-    fun normalizeName(): String {
-        return name.replace(Regex("""\s*\(.*?\)"""), "").trim()
+    companion object {
+        // DB normalized_name 컬럼과 동일한 규칙으로 정렬되어야 매칭이 일관됨.
+        // 1) 괄호와 안의 내용 제거 (앞뒤 공백 포함)
+        // 2) 끝의 '역' 접미사 제거
+        // 3) 양 끝 공백 trim
+        fun normalize(name: String): String {
+            return name
+                .replace(Regex(""" *\([^)]*\) *"""), "")
+                .removeSuffix("역")
+                .trim()
+        }
     }
 }

--- a/src/main/kotlin/com/deepromeet/atcha/transit/domain/subway/SubwayStation.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/domain/subway/SubwayStation.kt
@@ -32,14 +32,12 @@ class SubwayStation(
 
     companion object {
         // DB normalized_name 컬럼과 동일한 규칙으로 정렬되어야 매칭이 일관됨.
-        // 1) 괄호와 안의 내용 제거 (앞뒤 공백 포함)
-        // 2) 끝의 '역' 접미사 제거
-        // 3) 양 끝 공백 trim
+        // trim 을 먼저 둬야 "신촌역 " 처럼 뒤 공백 있는 입력의 '역' 접미사 제거가 동작.
         fun normalize(name: String): String {
             return name
+                .trim()
                 .replace(Regex(""" *\([^)]*\) *"""), "")
                 .removeSuffix("역")
-                .trim()
         }
     }
 }

--- a/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/repository/SubwayStationRepository.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/repository/SubwayStationRepository.kt
@@ -3,7 +3,6 @@ package com.deepromeet.atcha.transit.infrastructure.repository
 import com.deepromeet.atcha.transit.domain.subway.SubwayStation
 import com.deepromeet.atcha.transit.domain.subway.SubwayStationId
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
 
 interface SubwayStationRepository : JpaRepository<SubwayStation, SubwayStationId> {
     fun findByRouteCodeAndName(
@@ -18,17 +17,13 @@ interface SubwayStationRepository : JpaRepository<SubwayStation, SubwayStationId
 
     fun findByRouteCode(routeCode: String): List<SubwayStation>
 
-    @Query(
-        """
-        SELECT s
-        FROM SubwayStation s
-        WHERE s.routeCode = :routeCode
-        AND ( s.normalizedName = :normalizedName
-           OR s.name LIKE CONCAT('%(', :normalizedName, ')%') )
-        """
-    )
-    fun findStationByNameAndRoute(
+    fun findFirstByRouteCodeAndNormalizedName(
         routeCode: String,
         normalizedName: String
+    ): SubwayStation?
+
+    fun findFirstByRouteCodeAndNameLike(
+        routeCode: String,
+        namePattern: String
     ): SubwayStation?
 }

--- a/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/repository/SubwayStationRepository.kt
+++ b/src/main/kotlin/com/deepromeet/atcha/transit/infrastructure/repository/SubwayStationRepository.kt
@@ -23,11 +23,12 @@ interface SubwayStationRepository : JpaRepository<SubwayStation, SubwayStationId
         SELECT s
         FROM SubwayStation s
         WHERE s.routeCode = :routeCode
-        AND ( s.name = :name OR s.name LIKE CONCAT(:name, '(%') )
+        AND ( s.normalizedName = :normalizedName
+           OR s.name LIKE CONCAT('%(', :normalizedName, ')%') )
         """
     )
     fun findStationByNameAndRoute(
         routeCode: String,
-        name: String
+        normalizedName: String
     ): SubwayStation?
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #

## 📝작업 내용

- 지하철역 조회 쿼리를 LIKE 기반에서 정규화 컬럼(`normalizedName`) 동등 비교로 변경
- `SubwayStation`에 `normalize(name)` 컴패니언 함수 추가 (괄호 내용 / 끝의 `역` 접미사 / 양 끝 공백 제거)
- `SubwayStationRepository.findStationByNameAndRoute` 쿼리에 별칭 LIKE fallback 추가 (`이수` 입력 → `총신대입구(이수)` 매칭)
- `SubwayManager.getStation` 호출 시점에 입력값을 정규화 후 조회

### 배경

기존 쿼리는 `name = ? OR name LIKE CONCAT(?, '(%')` 형태라 다음 케이스에서 매칭이 실패했음:
- `역` 접미사 차이 (`신촌역` vs `신촌`)
- 괄호 부속명 (`총신대입구(이수)` ↔ `총신대입구`, `이수`)
- 공백 차이

DB 쪽 작업은 별도로 완료됨 (`normalized_name` 컬럼 + `(route_code, normalized_name)` 복합 인덱스 추가, 800/800 rows 백필). 코드 정규화 규칙과 DB 백필 규칙은 동일하게 맞춤.

## 💬리뷰 요구사항(선택)

- `SubwayStation.normalize()` 정규화 규칙(괄호 / `역` 접미사 / trim)이 DB 백필 규칙과 일치하는지 확인 부탁드립니다.
- 별칭 fallback (`s.name LIKE CONCAT('%(', :normalizedName, ')%')`) 이 의도한 케이스에만 매칭되는지 (`이수` → `총신대입구(이수)` 등) 봐주시면 좋습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **버그 수정**
  * 지하철 역 검색 시 역명 정규화 로직을 개선했습니다. 괄호, '역' 접미사 등의 불일치를 자동으로 처리하여 더 정확하고 안정적인 역 검색 결과를 제공합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/16th-team6-BE/pull/406?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->